### PR TITLE
Build instructions for GraphiQL example

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,17 @@ Current feature set:
 
 ### GraphiQL
 
-See `examples/server.ml` for a HTTP server accepting GraphQL requests and serving GraphiQL.
+To run a sample GraphQL server also serving GraphiQL, do the following:
+
+```bash
+git checkout git@github.com/andreas/ocaml-graphql-server.git
+cd ocaml-graphql-server
+opam pin add graphql-server .
+cd examples
+ocamlbuild -use-ocamlfind server.native && ./server.native
+```
+
+Now open [http://localhost:8080](http://localhost:8080).
 
 ### Defining a Schema
 

--- a/examples/_tags
+++ b/examples/_tags
@@ -1,0 +1,1 @@
+true: package(yojson,lwt,cohttp.lwt,graphql-server)


### PR DESCRIPTION
To run a sample GraphQL server also serving GraphiQL, do the following:

```bash
git checkout git@github.com/andreas/ocaml-graphql-server.git
cd ocaml-graphql-server
opam pin add graphql-server .
cd examples
ocamlbuild -use-ocamlfind server.native && ./server.native
```

Now open [http://localhost:8080](http://localhost:8080).