### PR TITLE
Parser improvements

### DIFF
--- a/src/graphql.mli
+++ b/src/graphql.mli
@@ -48,6 +48,7 @@ end
 (** Parsing of GraphQL documents. *)
 module Parser : sig
   type value =
+    | Null
     | Variable of string
     | Int of int
     | Float of float

--- a/src/graphql.mli
+++ b/src/graphql.mli
@@ -59,11 +59,7 @@ module Parser : sig
     | Object of key_value list
     [@@deriving sexp]
 
-  and key_value = {
-      name : string;
-      value : value
-    }
-    [@@deriving sexp]
+  and key_value = string * value [@@deriving sexp]
 
   type directive =
     {

--- a/src/graphql_parser.ml
+++ b/src/graphql_parser.ml
@@ -15,11 +15,7 @@ type value =
   | Object of key_value list
   [@@deriving sexp]
 
-and key_value = {
-    name : string;
-    value : value
-  }
-  [@@deriving sexp]
+and key_value = string * value [@@deriving sexp]
 
 type directive =
   {
@@ -171,7 +167,7 @@ let enum_value = name >>= function
 let value = fix (fun value' ->
   let list_value = lbrack *> rbrack *> return (List []) <|>
                    lift (fun l -> List l) (lbrack *> many value' <* rbrack)
-  and object_field = lift2 (fun name value -> { name; value }) (name <* colon) value'
+  and object_field = lift2 (fun name value -> name, value) (name <* colon) value'
   in
   let object_value = lbrace *> rbrace *> return (Object []) <|>
                      lift (fun p -> Object p) (lbrace *> many object_field <* rbrace)
@@ -187,7 +183,7 @@ let value = fix (fun value' ->
     object_value
 )
 
-let argument = lift2 (fun name value -> {name; value})
+let argument = lift2 (fun name value -> name, value)
                (name <* colon) value
 
 let arguments = lparen *> many argument <* rparen

--- a/src/graphql_parser.ml
+++ b/src/graphql_parser.ml
@@ -4,6 +4,7 @@ open Angstrom
 (* Language type definitions *)
 
 type value =
+  | Null
   | Variable of string
   | Int of int
   | Float of float
@@ -154,6 +155,7 @@ let int_chars    = ignored *> take_while1 is_int_char
 let float_chars  = ignored *> take_while1 is_float_char
 let name         = ignored *> take_while1 is_name_char 
 
+let null = string "null" *> return Null
 let variable = lift (fun n -> Variable n) (dollar *> name)
 let int_value = lift (fun i -> Int (int_of_string i)) int_chars
 let float_value = lift (fun f -> Float (float_of_string f)) float_chars
@@ -174,6 +176,7 @@ let value = fix (fun value' ->
   let object_value = lbrace *> rbrace *> return (Object []) <|>
                      lift (fun p -> Object p) (lbrace *> many object_field <* rbrace)
   in
+    null <|>
     variable <|>
     int_value <|>
     float_value <|>

--- a/src/graphql_parser.mli
+++ b/src/graphql_parser.mli
@@ -1,4 +1,5 @@
 type value =
+  | Null
   | Variable of string
   | Int of int
   | Float of float

--- a/src/graphql_parser.mli
+++ b/src/graphql_parser.mli
@@ -10,11 +10,7 @@ type value =
   | Object of key_value list
   [@@deriving sexp]
 
-and key_value = {
-    name : string;
-    value : value
-  }
-  [@@deriving sexp]
+and key_value = string * value [@@deriving sexp]
 
 type directive =
   {

--- a/test/data/introspection.sexp
+++ b/test/data/introspection.sexp
@@ -63,8 +63,7 @@
        (selection_set ())))
      (Field
       ((alias ()) (name fields)
-       (arguments (((name includeDeprecated) (value (Boolean true)))))
-       (directives ())
+       (arguments ((includeDeprecated (Boolean true)))) (directives ())
        (selection_set
         ((Field
           ((alias ()) (name name) (arguments ()) (directives ())
@@ -94,8 +93,7 @@
        (selection_set ((FragmentSpread ((name TypeRef) (directives ())))))))
      (Field
       ((alias ()) (name enumValues)
-       (arguments (((name includeDeprecated) (value (Boolean true)))))
-       (directives ())
+       (arguments ((includeDeprecated (Boolean true)))) (directives ())
        (selection_set
         ((Field
           ((alias ()) (name name) (arguments ()) (directives ())

--- a/test/data/kitchen_sink.sexp
+++ b/test/data/kitchen_sink.sexp
@@ -7,8 +7,7 @@
    (selection_set
     ((Field
       ((alias (whoever123is)) (name node)
-       (arguments (((name id) (value (List ((Int 123) (Int 456)))))))
-       (directives ())
+       (arguments ((id (List ((Int 123) (Int 456)))))) (directives ())
        (selection_set
         ((Field
           ((alias ()) (name id) (arguments ()) (directives ())
@@ -25,12 +24,9 @@
                    (selection_set ())))
                  (Field
                   ((alias (alias)) (name field1)
-                   (arguments
-                    (((name first) (value (Int 10)))
-                     ((name after) (value (Variable foo)))))
+                   (arguments ((first (Int 10)) (after (Variable foo))))
                    (directives
-                    (((name include)
-                      (arguments (((name if) (value (Variable foo))))))))
+                    (((name include) (arguments ((if (Variable foo)))))))
                    (selection_set
                     ((Field
                       ((alias ()) (name id) (arguments ()) (directives ())
@@ -38,9 +34,7 @@
                      (FragmentSpread ((name frag) (directives ())))))))))))))))
          (InlineFragment
           ((type_condition ())
-           (directives
-            (((name skip)
-              (arguments (((name unless) (value (Variable foo))))))))
+           (directives (((name skip) (arguments ((unless (Variable foo)))))))
            (selection_set
             ((Field
               ((alias ()) (name id) (arguments ()) (directives ())
@@ -56,7 +50,7 @@
    (directives ())
    (selection_set
     ((Field
-      ((alias ()) (name like) (arguments (((name story) (value (Int 123)))))
+      ((alias ()) (name like) (arguments ((story (Int 123))))
        (directives (((name defer) (arguments ()))))
        (selection_set
         ((Field
@@ -74,7 +68,7 @@
    (selection_set
     ((Field
       ((alias ()) (name storyLikeSubscribe)
-       (arguments (((name input) (value (Variable input))))) (directives ())
+       (arguments ((input (Variable input)))) (directives ())
        (selection_set
         ((Field
           ((alias ()) (name story) (arguments ()) (directives ())
@@ -97,7 +91,17 @@
     ((Field
       ((alias ()) (name foo)
        (arguments
-        (((name size) (value (Variable size)))
-         ((name bar) (value (Variable b)))
-         ((name obj) (value (Object (((name key) (value (String value)))))))))
-       (directives ()) (selection_set ()))))))))
+        ((size (Variable size)) (bar (Variable b))
+         (obj (Object ((key (String value)))))))
+       (directives ()) (selection_set ())))))))
+ (Operation
+  ((optype Query) (name ()) (variable_definitions ()) (directives ())
+   (selection_set
+    ((Field
+      ((alias ()) (name unnamed)
+       (arguments
+        ((truthy (Boolean true)) (falsey (Boolean false)) (nullish Null)))
+       (directives ()) (selection_set ())))
+     (Field
+      ((alias ()) (name query) (arguments ()) (directives ())
+       (selection_set ()))))))))


### PR DESCRIPTION
- Parser now handles `null` values.
- `Parser.key_value` a tuple `(string, Parser.value)` rather than a record.
- Floats and ints are now parsed together as "number", instead of separately, which didn't work correctly.