### PR TITLE
Refactor schema execution

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -3,6 +3,7 @@ PKG sexplib
 PKG yojson
 PKG cohttp.lwt
 PKG alcotest
+PKG rresult
 B _build/*
 S test
 S src

--- a/_tags
+++ b/_tags
@@ -1,7 +1,7 @@
 true: bin_annot, debug, safe_string
 true: short_paths
 
-true: package(angstrom,sexplib,ppx_sexp_conv,ppx_sexp_value,yojson,lwt)
+true: package(angstrom,sexplib,ppx_sexp_conv,ppx_sexp_value,yojson,lwt,rresult)
 
 <src>: include
 <test>: include

--- a/pkg/META
+++ b/pkg/META
@@ -1,6 +1,6 @@
 description = "Library for writing GraphQL servers"
 version = "%%VERSION_NUM%%"
-requires = "angstrom sexplib ppx_sexp_conv ppx_sexp_value yojson cohttp.lwt"
+requires = "angstrom sexplib ppx_sexp_conv ppx_sexp_value yojson cohttp.lwt rresult"
 archive(byte) = "graphql.cma"
 archive(native) = "graphql.cmxa"
 plugin(byte) = "graphql.cma"

--- a/test/schema_test.ml
+++ b/test/schema_test.ml
@@ -7,7 +7,7 @@ let test_query schema ctx query expected =
       failwith (Format.sprintf "Failed to parse query (%s): %s" err query)
 
 let test_simple () =
-  test_query Test_schema.schema () "{ users { id } }" "{\"users\":[{\"id\":1},{\"id\":2}]}"
+  test_query Test_schema.schema () "{ users { id } }" "{\"data\":{\"users\":[{\"id\":1},{\"id\":2}]}}"
 
 let suite = [
   "simple", `Quick, test_simple;


### PR DESCRIPTION
- `Graphql.execute` now returns `(Yojson.Basic.json, string) result` rather than `Yojson.Basic.json`.
- Introduce `rresult` for more elegant `result` computations.
- Refactor some of the internals for schema execution.