### PR TITLE
Argument support

### DIFF
--- a/examples/_tags
+++ b/examples/_tags
@@ -1,1 +1,1 @@
-true: package(yojson,lwt,cohttp.lwt,graphql-server)
+true: package(yojson,lwt,cohttp.lwt,rresult,graphql-server)

--- a/examples/server.ml
+++ b/examples/server.ml
@@ -23,16 +23,19 @@ let user = Schema.(obj
   ~fields:[
     field
       ~name:"id"
+      ~args:Arg.[]
       ~typ:(non_null int)
       ~resolve:(fun () p -> p.id)
     ;
     field
       ~name:"name"
+      ~args:Arg.[]
       ~typ:(non_null string)
       ~resolve:(fun () p -> p.name)
     ;
     field
       ~name:"role"
+      ~args:Arg.[]
       ~typ:(non_null role)
       ~resolve:(fun () p -> p.role)
   ]
@@ -42,10 +45,30 @@ let schema = Schema.(schema
     ~fields:[
       field
         ~name:"users"
+        ~args:Arg.[]
         ~typ:(non_null (list (non_null user)))
         ~resolve:(fun () () -> users)
+      ;
+      field
+        ~name:"greeter"
+        ~typ:string
+        ~args:Arg.[
+          arg "config" ~typ:(non_null (obj ~name:"greeter_config" ~coerce:(fun greeting name -> (greeting, name)) ~fields:[
+            arg "greeting" ~typ:(non_null string);
+            arg "name" ~typ:(non_null string)
+          ]))
+        ]
+        ~resolve:(fun () () (greeting, name) ->
+          Some (Format.sprintf "%s, %s" greeting name)
+        )
+      ;
     ]
 )
+
+let execute query =
+  let open Rresult in
+  Graphql.Parser.parse query >>| fun doc ->
+  Graphql.execute schema () doc
 
 let callback conn (req : Cohttp.Request.t) body =
   Lwt_io.printf "Req: %s\n" req.resource;
@@ -57,12 +80,12 @@ let callback conn (req : Cohttp.Request.t) body =
       Lwt_io.printf "Body: %s\n" query_json;
       let query = Yojson.Basic.from_string query_json |> Yojson.Basic.Util.member "query" |> Yojson.Basic.Util.to_string in
       Lwt_io.printf "Query: %s\n" query;
-      match Graphql.Parser.parse query with
-      | Ok doc ->
-          let data = Graphql.execute schema () doc in
-          let rsp = `Assoc [("data", data)] |> Yojson.Basic.to_string in
+      match execute query with
+      | Ok data ->
+          let rsp = Yojson.Basic.to_string data in
           C.Server.respond_string ~status:`OK ~body:rsp ()
-      | Error err -> C.Server.respond_string ~status:`Internal_server_error ~body:err ()
+      | Error err ->
+          C.Server.respond_string ~status:`Internal_server_error ~body:err ()
     end
   | _ -> C.Server.respond_string ~status:`Not_found ~body:"" ()
 

--- a/src/graphql.mli
+++ b/src/graphql.mli
@@ -1,50 +1,5 @@
 (** GraphQL schema constructor, document parser and query executer *)
 
-(** Constructing GraphQL schemas. *)
-module Schema : sig
-
-  (** {3 Base types } *)
-
-  type 'ctx schema
-
-  type ('ctx, 'src) field
-
-  type ('ctx, 'src) typ
-
-  (** {3 Constructors } *)
-
-  val schema : fields:('ctx, unit) field list ->
-               'ctx schema
-
-  val obj : name:string ->
-            fields:('ctx, 'src) field list ->
-            ('ctx, 'src option) typ
-
-  val field : name:string ->
-              typ:('ctx, 'a) typ ->
-              resolve:('ctx -> 'src -> 'a) ->
-              ('ctx, 'src) field
-
-  val enum : name:string ->
-             values:('a * string) list ->
-             ('ctx, 'a option) typ
-
-  val scalar : name:string ->
-               coerce:('a -> Yojson.Basic.json) ->
-               ('ctx, 'a option) typ
-
-  val list : ('ctx, 'src) typ -> ('ctx, 'src list option) typ
-
-  val non_null : ('ctx, 'src option) typ -> ('ctx, 'src) typ
-
-  (** {3 Built-in scalars} *)
-
-  val int    : ('ctx, int option) typ
-  val string : ('ctx, string option) typ
-  val bool   : ('ctx, bool option) typ
-  val float  : ('ctx, float option) typ
-end
-
 (** Parsing of GraphQL documents. *)
 module Parser : sig
   type value =
@@ -148,6 +103,89 @@ module Parser : sig
     [@@deriving sexp]
 
   val parse : string -> (document, string) result
+end
+
+(** Constructing GraphQL schemas. *)
+module Schema : sig
+
+  (** {3 Base types } *)
+
+  type 'ctx schema
+
+  type ('ctx, 'src) field
+
+  type ('ctx, 'src) typ
+
+  (** {3 Constructors } *)
+
+  val schema : fields:('ctx, unit) field list ->
+               'ctx schema
+
+  val obj : name:string ->
+            fields:('ctx, 'src) field list ->
+            ('ctx, 'src option) typ
+
+  module Arg : sig
+    type (_, _) arg
+    type (_, _) arg_typ
+
+    type (_, _) arg_list =
+      | [] : ('a, 'a) arg_list
+      | (::) : ('b, 'c -> 'b) arg * ('a, 'b) arg_list -> ('a, 'c -> 'b) arg_list
+
+    val arg : ?default:'a option ->
+              string ->
+              typ:('a, 'b) arg_typ ->
+              ('a, 'b) arg
+
+    val scalar : name:string ->
+                 coerce:(Parser.value -> ('b, string) result) ->
+                 ('a, 'b option -> 'a) arg_typ
+
+    val enum : name:string ->
+               values:(string * 'b) list ->
+               ('a, 'b option -> 'a) arg_typ
+
+    val obj : name:string ->
+              fields:('c, 'b) arg_list ->
+              coerce:'b ->
+              ('a, 'c option -> 'a) arg_typ
+
+    (* Argument constructors *)
+    val int : ('a, int option -> 'a) arg_typ
+    val string : ('a, string option -> 'a) arg_typ
+    val bool : ('a, bool option -> 'a) arg_typ
+    val float : ('a, float option -> 'a) arg_typ
+    val guid : ('a, string option -> 'a) arg_typ
+    val list : ('a, 'b -> 'a) arg_typ -> ('a, 'b list option -> 'a) arg_typ
+    val non_null : ('a, 'b option -> 'a) arg_typ -> ('a, 'b -> 'a) arg_typ
+  end
+
+  val field : name:string ->
+              typ:('ctx, 'a) typ ->
+              args:('a, 'b) Arg.arg_list ->
+              resolve:('ctx -> 'src -> 'b) ->
+              ('ctx, 'src) field
+
+  val enum : name:string ->
+             values:('a * string) list ->
+             ('ctx, 'a option) typ
+
+  val scalar : name:string ->
+               coerce:('a -> Yojson.Basic.json) ->
+               ('ctx, 'a option) typ
+
+  val list : ('ctx, 'src) typ -> ('ctx, 'src list option) typ
+
+  val non_null : ('ctx, 'src option) typ -> ('ctx, 'src) typ
+
+  (** {3 Built-in scalars} *)
+
+  val int    : ('ctx, int option) typ
+  val string : ('ctx, string option) typ
+  val guid   : ('ctx, string option) typ
+  val bool   : ('ctx, bool option) typ
+  val float  : ('ctx, float option) typ
 end
 
 val execute : 'ctx Schema.schema -> 'ctx -> Parser.document -> Yojson.Basic.json

--- a/test/argument_test.ml
+++ b/test/argument_test.ml
@@ -1,0 +1,90 @@
+open Graphql
+open Test_common
+
+let echo : 'a. unit -> unit -> 'a -> 'a = fun _ _ x -> x
+
+let echo_field name field_typ arg_typ = Schema.(
+      field ~name
+            ~typ:field_typ
+            ~args:Arg.[
+              arg "x" ~typ:arg_typ
+            ]
+            ~resolve:echo
+)
+
+type colors = Red | Green | Blue
+let color_enum     = Schema.enum ~name:"color" ~values:[Red, "RED"; Green, "GREEN"; Blue, "BLUE"]
+let color_enum_arg = Schema.Arg.enum ~name:"color" ~values:["RED", Red; "GREEN", Green; "BLUE", Blue]
+
+let person_arg = Schema.Arg.(obj ~name:"person" ~fields:Arg.[
+    arg "title" ~typ:string;
+    arg "first_name" ~typ:(non_null string);
+    arg "last_name" ~typ:(non_null string);
+  ]
+  ~coerce:(fun title first last -> (title, first, last))
+)
+
+let echo_schema =
+  Schema.(schema ~fields:[
+      echo_field "string" string Arg.string;
+      echo_field "float" float Arg.float;
+      echo_field "int" int Arg.int;
+      echo_field "bool" bool Arg.bool;
+      echo_field "enum" color_enum color_enum_arg;
+      echo_field "id" guid Arg.guid;
+      echo_field "bool_list" (list bool) Arg.(list bool);
+      field ~name:"input_obj"
+            ~typ:(non_null string)
+            ~args:Arg.[
+              arg "x" ~typ:(non_null person_arg)
+            ]
+            ~resolve:(fun () () (title, first, last) -> first ^ " " ^ last)
+  ])
+
+let suite : (string * [>`Quick] * (unit -> unit)) list = [
+  ("string argument", `Quick, fun () ->
+    test_query echo_schema () "{ string(x: \"foo\") }" "{\"data\":{\"string\":\"foo\"}}"
+  );
+  ("float argument", `Quick, fun () ->
+    test_query echo_schema () "{ float(x: 42.5) }" "{\"data\":{\"float\":42.5}}"
+  );
+  ("int argument", `Quick, fun () ->
+    test_query echo_schema () "{ int(x: 42) }" "{\"data\":{\"int\":42}}"
+  );
+  ("bool argument", `Quick, fun () ->
+    test_query echo_schema () "{ bool(x: false) }" "{\"data\":{\"bool\":false}}"
+  );
+  ("enum argument", `Quick, fun () ->
+    test_query echo_schema () "{ enum(x: RED) }" "{\"data\":{\"enum\":\"RED\"}}"
+  );
+  ("list argument", `Quick, fun () ->
+    test_query echo_schema () "{ bool_list(x: [false, true]) }" "{\"data\":{\"bool_list\":[false,true]}}"
+  );
+  ("input object argument", `Quick, fun () ->
+    test_query echo_schema () "{ input_obj(x: {title: \"Mr\", first_name: \"John\", last_name: \"Doe\"}) }" "{\"data\":{\"input_obj\":\"John Doe\"}}"
+  );
+  ("null for optional argument", `Quick, fun () ->
+    test_query echo_schema () "{ string(x: null) }" "{\"data\":{\"string\":null}}"
+  );
+  ("null for required argument", `Quick, fun () ->
+    test_query echo_schema () "{ input_obj(x: null) }" "{\"errors\":[{\"message\":\"Missing required argument\"}]}"
+  );
+  ("missing optional argument", `Quick, fun () ->
+    test_query echo_schema () "{ string }" "{\"data\":{\"string\":null}}"
+  );
+  ("missing required argument", `Quick, fun () ->
+    test_query echo_schema () "{ input_obj }" "{\"errors\":[{\"message\":\"Missing required argument\"}]}"
+  );
+  ("input coercion: single value to list", `Quick, fun () ->
+    test_query echo_schema () "{ bool_list(x: false) }" "{\"data\":{\"bool_list\":[false]}}"
+  );
+  ("input coercion: int to float", `Quick, fun () ->
+    test_query echo_schema () "{ float(x: 42) }" "{\"data\":{\"float\":42.0}}"
+  );
+  ("input coercion: int to ID", `Quick, fun () ->
+    test_query echo_schema () "{ id(x: 42) }" "{\"data\":{\"id\":\"42\"}}"
+  );
+  ("input coercion: string to ID", `Quick, fun () ->
+    test_query echo_schema () "{ id(x: \"42\") }" "{\"data\":{\"id\":\"42\"}}"
+  );
+]

--- a/test/schema_test.ml
+++ b/test/schema_test.ml
@@ -1,14 +1,8 @@
-let test_query schema ctx query expected =
-  match Graphql.Parser.parse query with
-  | Ok doc ->
-      let result = Graphql.execute schema ctx doc |> Yojson.Basic.to_string in
-      Alcotest.(check string) "invalid execution result" expected result
-  | Error err ->
-      failwith (Format.sprintf "Failed to parse query (%s): %s" err query)
-
-let test_simple () =
-  test_query Test_schema.schema () "{ users { id } }" "{\"data\":{\"users\":[{\"id\":1},{\"id\":2}]}}"
+open Graphql
+open Test_common
 
 let suite = [
-  "simple", `Quick, test_simple;
+  ("execution", `Quick, fun () ->
+    test_query Test_schema.schema () "{ users { id } }" "{\"data\":{\"users\":[{\"id\":1},{\"id\":2}]}}"
+  );
 ]

--- a/test/test.ml
+++ b/test/test.ml
@@ -1,5 +1,6 @@
 let () =
   Alcotest.run "graphql-server" [
-    "parser", Parser_test.suite;
-    "schema", Schema_test.suite;
+    "parser",    Parser_test.suite;
+    "schema",    Schema_test.suite;
+    "arguments", Argument_test.suite;
   ]

--- a/test/test_common.ml
+++ b/test/test_common.ml
@@ -1,0 +1,7 @@
+let test_query schema ctx query expected =
+  match Graphql.Parser.parse query with
+  | Error err -> failwith err
+  | Ok doc ->
+      let result = Graphql.execute schema ctx doc in
+      let result' = Yojson.Basic.to_string result in
+      Alcotest.(check string) "invalid execution result" expected result'

--- a/test/test_schema.ml
+++ b/test/test_schema.ml
@@ -21,16 +21,19 @@ let user = Schema.(obj
     field
       ~name:"id"
       ~typ:(non_null int)
+      ~args:Arg.[]
       ~resolve:(fun () p -> p.id)
     ;
     field
       ~name:"name"
       ~typ:(non_null string)
+      ~args:Arg.[]
       ~resolve:(fun () p -> p.name)
     ;
     field
       ~name:"role"
       ~typ:(non_null role)
+      ~args:Arg.[]
       ~resolve:(fun () p -> p.role)
   ]
 )
@@ -40,6 +43,7 @@ let schema = Schema.(schema
       field
         ~name:"users"
         ~typ:(non_null (list (non_null user)))
+        ~args:Arg.[]
         ~resolve:(fun () () -> users)
     ]
 )


### PR DESCRIPTION
A field new field `args` has been added to the field GADT:

```ocaml
type _ field = Field : {
      name    : string;
      args    : ('out, 'args) Arg.arg_list; (* <-- this field is new! *)
      typ     : ('ctx, 'out) typ;
      resolve : 'ctx -> 'src -> 'args;
    } -> ('ctx, 'src) field
```

where `('a, 'b) Arg.arg_list` is a heterogenous list of arguments. The type of `resolve` is tied to the arguments in the following manner:

- If args are empty then the type is `('out, 'out) Arg.arg_list` and the type of `resolve` is `'ctx -> 'src -> 'out` as expected.
- If args have the the type `('out, string option -> int -> 'out) Arg.arg_list` (representing two arguments of type `string option` and `int`), then the type of `resolve` becomes `'ctx -> 'src -> string option -> int -> 'out)`.

At compile time we thus ensure that `resolve` agrees with the declared arguments. Also, when the `resolve` function is invoked, the arguments have already been validated and coerced to the right type.

Arguments are specified with the new labelled argument `args` when calling `Schema.field`, and are most conveniently constructed by opening the module `Schema.Arg` locally like so:

```ocaml
Schema.Arg.[
  arg "numbers" ~typ:(list (non_null int));
  arg "foo" ~typ:string
]
```

The above expression would have the type `('a, int list option -> string -> 'a) Arg.arg_list`. The constructors `[]` and `::` have been defined in in `Schema.Arg` to provide convenient syntax.

Here is a final more complete example:

```ocaml
Schema.(schema
  ~fields:[
    field
      ~name: "greeter"
      ~typ:(non_null string)
      ~args:Arg.[
        arg "greeting" ~typ:(non_null string);
        arg "name" ~typ:(non_null string);
      ]
      ~resolve:(fun ctx src greeting name -> Format.sprintf "%s, %s" greeting name)
    ;
  ]
)
```

This schema would respond to queries like

```
{ greeter(greeting: "hello", name: "world") }
```

and would return

```json
{ "data": { "greeter": "hello, world"  } }
```

Closes #1.