### PR TITLE
Fix build dependencies for lwt/async subpackages

### DIFF
--- a/_tags
+++ b/_tags
@@ -1,7 +1,9 @@
 true: bin_annot, debug, safe_string
 true: short_paths
 
-true: package(angstrom,sexplib,ppx_sexp_conv,ppx_sexp_value,yojson,lwt,rresult,async_kernel)
+true: package(angstrom,sexplib,ppx_sexp_conv,ppx_sexp_value,yojson,rresult)
+<src/*_async.*>: package(async_kernel)
+<src/*_lwt.*>: package(lwt)
 
 <src>: include
 <test>: include

--- a/pkg/META
+++ b/pkg/META
@@ -1,6 +1,6 @@
 description = "Library for writing GraphQL servers"
 version = "%%VERSION_NUM%%"
-requires = "angstrom sexplib ppx_sexp_conv ppx_sexp_value yojson cohttp.lwt rresult"
+requires = "angstrom sexplib ppx_sexp_conv ppx_sexp_value yojson rresult"
 archive(byte) = "graphql.cma"
 archive(native) = "graphql.cmxa"
 plugin(byte) = "graphql.cma"


### PR DESCRIPTION
Fix dependencies as specified in `_tags` and `META`:

- `lwt` should only be required when building `graphql.lwt`.
- `async_kernel` should only be required when building `graphql.async`.
- Neither should be required for building `graphql`.

fixes #17 