### PR TITLE
Variable support in query execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,15 @@
 Current feature set:
 
 - [x] GraphQL parser in pure OCaml using [angstrom](https://github.com/inhabitedtype/angstrom) (April 2016 RFC draft)
-- [x] Basic execution
-- [x] Basic introspection
-- [x] Argument support
+- [x] Execution
+- [x] Introspection
+- [x] Arguments
+- [x] Variables
 - [x] Lwt support
 - [x] Async support
 - [x] Example with HTTP server and GraphiQL
 
-![GraphiQL Example](https://cloud.githubusercontent.com/assets/2518/20041922/403ed918-a471-11e6-8178-1cd22dbc4658.png)
+![GraphiQL Example](https://cloud.githubusercontent.com/assets/2518/22173954/8d1e5bbe-dfd1-11e6-9a7e-4f93d0ce2e24.png)
 
 ## Documentation
 
@@ -87,9 +88,20 @@ let schema = Schema.(schema
 
 ### Running a Query
 
+Without variables:
+
 ```ocaml
-let query = Graphql_parser.parse some_string in
+let query = Graphql_parser.parse "{ users { name } }" in
 Graphql.Schema.execute schema ctx query
+```
+
+With variables parsed from JSON:
+
+```ocaml
+let query = Graphql_parser.parse "{ users(limit: $x) { name } }" in
+let json_variables = Yojson.Basic.(from_string "{\"x\": 42}" |> Util.to_assoc) in
+let variables = (json_variables :> (string * Graphql_parser.const_value) list)
+Graphql.Schema.execute schema ctx ~variables query
 ```
 
 ### Lwt Support

--- a/examples/index.html
+++ b/examples/index.html
@@ -18,11 +18,11 @@ add "&raw" to the end of the URL within a browser.
       width: 100%;
     }
   </style>
-  <link href="//cdn.jsdelivr.net/graphiql/0.7.8/graphiql.css" rel="stylesheet" />
+  <link href="//cdn.jsdelivr.net/graphiql/0.8.1/graphiql.css" rel="stylesheet" />
   <script src="//cdn.jsdelivr.net/fetch/0.9.0/fetch.min.js"></script>
   <script src="//cdn.jsdelivr.net/react/15.3.2/react.min.js"></script>
   <script src="//cdn.jsdelivr.net/react/15.3.2/react-dom.min.js"></script>
-  <script src="//cdn.jsdelivr.net/graphiql/0.7.8/graphiql.js"></script>
+  <script src="//cdn.jsdelivr.net/graphiql/0.8.1/graphiql.js"></script>
 </head>
 <body>
   <script>

--- a/examples/server.ml
+++ b/examples/server.ml
@@ -66,10 +66,10 @@ let json_err = function
   | Ok _ as ok -> ok
   | Error err -> Error (`String err)
 
-let execute query =
+let execute variables query =
   let open Lwt_result in
   Lwt.return @@ json_err @@ Graphql_parser.parse query >>= fun doc ->
-  Schema.execute schema () doc
+  Schema.execute schema () ~variables doc
 
 let callback conn (req : Cohttp.Request.t) body =
   Lwt_io.printf "Req: %s\n" req.resource;
@@ -79,9 +79,15 @@ let callback conn (req : Cohttp.Request.t) body =
     begin
       Cohttp_lwt_body.to_string body >>= fun query_json ->
       Lwt_io.printf "Body: %s\n" query_json;
-      let query = Yojson.Basic.from_string query_json |> Yojson.Basic.Util.member "query" |> Yojson.Basic.Util.to_string in
+      let query = Yojson.Basic.(from_string query_json |> Util.member "query" |> Util.to_string)
+      in
+      let variables =
+        try
+          Yojson.Basic.(from_string query_json |> Util.member "variables" |> Util.to_assoc)
+        with _ -> []
+      in
       Lwt_io.printf "Query: %s\n" query;
-      execute query >>= function
+      execute (variables :> (string * Graphql_parser.const_value) list) query >>= function
       | Ok data ->
           let body = Yojson.Basic.to_string data in
           C.Server.respond_string ~status:`OK ~body ()

--- a/opam
+++ b/opam
@@ -15,7 +15,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}
-  "angstrom"
+  "angstrom" {>= "0.3.0"}
   "sexplib"
   "ppx_sexp_conv"
   "ppx_sexp_value"

--- a/src/graphql_intf.ml
+++ b/src/graphql_intf.ml
@@ -33,7 +33,7 @@ module type Schema = sig
               ('a, 'b) arg
 
     val scalar : name:string ->
-                coerce:(Graphql_parser.value -> ('b, string) result) ->
+                coerce:(Graphql_parser.const_value -> ('b, string) result) ->
                 ('a, 'b option -> 'a) arg_typ
 
     val enum : name:string ->
@@ -87,7 +87,9 @@ module type Schema = sig
   val bool   : ('ctx, bool option) typ
   val float  : ('ctx, float option) typ
 
-  val execute : 'ctx schema -> 'ctx -> Graphql_parser.document -> (Yojson.Basic.json, Yojson.Basic.json) result io
-  (** [execute schema ctx doc] evaluates the [doc] against [schema] with the
-      given context [ctx]. *)
+  type variables = (string * Graphql_parser.const_value) list
+
+  val execute : 'ctx schema -> 'ctx -> ?variables:variables -> Graphql_parser.document -> (Yojson.Basic.json, Yojson.Basic.json) result io
+  (** [execute schema ctx variables doc] evaluates the [doc] against [schema]
+      with the given context [ctx] and [variables]. *)
 end

--- a/src/graphql_parser.mli
+++ b/src/graphql_parser.mli
@@ -1,21 +1,30 @@
-type value =
-  | Null
-  | Variable of string
-  | Int of int
-  | Float of float
-  | String of string
-  | Boolean of bool
-  | Enum of string
-  | List of value list
-  | Object of key_value list
-  [@@deriving sexp]
+type const_value = [
+  | `Null
+  | `Int of int
+  | `Float of float
+  | `String of string
+  | `Bool of bool
+  | `Enum of string
+  | `List of const_value list
+  | `Assoc of (string * const_value) list
+] [@@deriving sexp]
 
-and key_value = string * value [@@deriving sexp]
+type value = [
+  | `Null
+  | `Int of int
+  | `Float of float
+  | `String of string
+  | `Bool of bool
+  | `Enum of string
+  | `Variable of string
+  | `List of value list
+  | `Assoc of (string * value) list
+] [@@deriving sexp]
 
 type directive =
   {
     name : string;
-    arguments : key_value list;
+    arguments : (string * value) list;
   }
   [@@deriving sexp]
 
@@ -36,7 +45,7 @@ and field =
   {
     alias : string option;
     name : string;
-    arguments : key_value list;
+    arguments : (string * value) list;
     directives : directive list;
     selection_set : selection list;
   }
@@ -69,7 +78,7 @@ type variable_definition =
   {
     name : string;
     typ : typ;
-    default_value : value option;
+    default_value : const_value option;
   }
   [@@deriving sexp]
 

--- a/test/argument_test.ml
+++ b/test/argument_test.ml
@@ -1,90 +1,49 @@
-open Graphql
-open Test_common
-
-let echo : 'a. unit -> unit -> 'a -> 'a = fun _ _ x -> x
-
-let echo_field name field_typ arg_typ = Schema.(
-      field name
-            ~typ:field_typ
-            ~args:Arg.[
-              arg "x" ~typ:arg_typ
-            ]
-            ~resolve:echo
-)
-
-type colors = Red | Green | Blue
-let color_enum     = Schema.enum ~name:"color" ~values:[Red, "RED"; Green, "GREEN"; Blue, "BLUE"]
-let color_enum_arg = Schema.Arg.enum ~name:"color" ~values:["RED", Red; "GREEN", Green; "BLUE", Blue]
-
-let person_arg = Schema.Arg.(obj ~name:"person" ~fields:Arg.[
-    arg "title" ~typ:string;
-    arg "first_name" ~typ:(non_null string);
-    arg "last_name" ~typ:(non_null string);
-  ]
-  ~coerce:(fun title first last -> (title, first, last))
-)
-
-let echo_schema =
-  Schema.(schema ~fields:[
-      echo_field "string" string Arg.string;
-      echo_field "float" float Arg.float;
-      echo_field "int" int Arg.int;
-      echo_field "bool" bool Arg.bool;
-      echo_field "enum" color_enum color_enum_arg;
-      echo_field "id" guid Arg.guid;
-      echo_field "bool_list" (list bool) Arg.(list bool);
-      field "input_obj"
-            ~typ:(non_null string)
-            ~args:Arg.[
-              arg "x" ~typ:(non_null person_arg)
-            ]
-            ~resolve:(fun () () (title, first, last) -> first ^ " " ^ last)
-  ])
+let test_query = Test_common.test_query Echo_schema.schema ()
 
 let suite : (string * [>`Quick] * (unit -> unit)) list = [
   ("string argument", `Quick, fun () ->
-    test_query echo_schema () "{ string(x: \"foo\") }" "{\"data\":{\"string\":\"foo\"}}"
+    test_query "{ string(x: \"foo\") }" "{\"data\":{\"string\":\"foo\"}}"
   );
   ("float argument", `Quick, fun () ->
-    test_query echo_schema () "{ float(x: 42.5) }" "{\"data\":{\"float\":42.5}}"
+    test_query "{ float(x: 42.5) }" "{\"data\":{\"float\":42.5}}"
   );
   ("int argument", `Quick, fun () ->
-    test_query echo_schema () "{ int(x: 42) }" "{\"data\":{\"int\":42}}"
+    test_query "{ int(x: 42) }" "{\"data\":{\"int\":42}}"
   );
   ("bool argument", `Quick, fun () ->
-    test_query echo_schema () "{ bool(x: false) }" "{\"data\":{\"bool\":false}}"
+    test_query "{ bool(x: false) }" "{\"data\":{\"bool\":false}}"
   );
   ("enum argument", `Quick, fun () ->
-    test_query echo_schema () "{ enum(x: RED) }" "{\"data\":{\"enum\":\"RED\"}}"
+    test_query "{ enum(x: RED) }" "{\"data\":{\"enum\":\"RED\"}}"
   );
   ("list argument", `Quick, fun () ->
-    test_query echo_schema () "{ bool_list(x: [false, true]) }" "{\"data\":{\"bool_list\":[false,true]}}"
+    test_query "{ bool_list(x: [false, true]) }" "{\"data\":{\"bool_list\":[false,true]}}"
   );
   ("input object argument", `Quick, fun () ->
-    test_query echo_schema () "{ input_obj(x: {title: \"Mr\", first_name: \"John\", last_name: \"Doe\"}) }" "{\"data\":{\"input_obj\":\"John Doe\"}}"
+    test_query "{ input_obj(x: {title: \"Mr\", first_name: \"John\", last_name: \"Doe\"}) }" "{\"data\":{\"input_obj\":\"John Doe\"}}"
   );
   ("null for optional argument", `Quick, fun () ->
-    test_query echo_schema () "{ string(x: null) }" "{\"data\":{\"string\":null}}"
+    test_query "{ string(x: null) }" "{\"data\":{\"string\":null}}"
   );
   ("null for required argument", `Quick, fun () ->
-    test_query echo_schema () "{ input_obj(x: null) }" "{\"errors\":[{\"message\":\"Missing required argument\"}]}"
+    test_query "{ input_obj(x: null) }" "{\"errors\":[{\"message\":\"Missing required argument\"}]}"
   );
   ("missing optional argument", `Quick, fun () ->
-    test_query echo_schema () "{ string }" "{\"data\":{\"string\":null}}"
+    test_query "{ string }" "{\"data\":{\"string\":null}}"
   );
   ("missing required argument", `Quick, fun () ->
-    test_query echo_schema () "{ input_obj }" "{\"errors\":[{\"message\":\"Missing required argument\"}]}"
+    test_query "{ input_obj }" "{\"errors\":[{\"message\":\"Missing required argument\"}]}"
   );
   ("input coercion: single value to list", `Quick, fun () ->
-    test_query echo_schema () "{ bool_list(x: false) }" "{\"data\":{\"bool_list\":[false]}}"
+    test_query "{ bool_list(x: false) }" "{\"data\":{\"bool_list\":[false]}}"
   );
   ("input coercion: int to float", `Quick, fun () ->
-    test_query echo_schema () "{ float(x: 42) }" "{\"data\":{\"float\":42.0}}"
+    test_query "{ float(x: 42) }" "{\"data\":{\"float\":42.0}}"
   );
   ("input coercion: int to ID", `Quick, fun () ->
-    test_query echo_schema () "{ id(x: 42) }" "{\"data\":{\"id\":\"42\"}}"
+    test_query "{ id(x: 42) }" "{\"data\":{\"id\":\"42\"}}"
   );
   ("input coercion: string to ID", `Quick, fun () ->
-    test_query echo_schema () "{ id(x: \"42\") }" "{\"data\":{\"id\":\"42\"}}"
+    test_query "{ id(x: \"42\") }" "{\"data\":{\"id\":\"42\"}}"
   );
 ]

--- a/test/data/introspection.sexp
+++ b/test/data/introspection.sexp
@@ -62,8 +62,8 @@
       ((alias ()) (name description) (arguments ()) (directives ())
        (selection_set ())))
      (Field
-      ((alias ()) (name fields)
-       (arguments ((includeDeprecated (Boolean true)))) (directives ())
+      ((alias ()) (name fields) (arguments ((includeDeprecated (Bool true))))
+       (directives ())
        (selection_set
         ((Field
           ((alias ()) (name name) (arguments ()) (directives ())
@@ -93,7 +93,7 @@
        (selection_set ((FragmentSpread ((name TypeRef) (directives ())))))))
      (Field
       ((alias ()) (name enumValues)
-       (arguments ((includeDeprecated (Boolean true)))) (directives ())
+       (arguments ((includeDeprecated (Bool true)))) (directives ())
        (selection_set
         ((Field
           ((alias ()) (name name) (arguments ()) (directives ())

--- a/test/data/kitchen_sink.sexp
+++ b/test/data/kitchen_sink.sexp
@@ -92,7 +92,7 @@
       ((alias ()) (name foo)
        (arguments
         ((size (Variable size)) (bar (Variable b))
-         (obj (Object ((key (String value)))))))
+         (obj (Assoc ((key (String value)))))))
        (directives ()) (selection_set ())))))))
  (Operation
   ((optype Query) (name ()) (variable_definitions ()) (directives ())
@@ -100,7 +100,7 @@
     ((Field
       ((alias ()) (name unnamed)
        (arguments
-        ((truthy (Boolean true)) (falsey (Boolean false)) (nullish Null)))
+        ((truthy (Bool true)) (falsey (Bool false)) (nullish Null)))
        (directives ()) (selection_set ())))
      (Field
       ((alias ()) (name query) (arguments ()) (directives ())

--- a/test/echo_schema.ml
+++ b/test/echo_schema.ml
@@ -1,0 +1,41 @@
+open Graphql
+
+let echo : 'a. unit -> unit -> 'a -> 'a = fun _ _ x -> x
+
+let echo_field name field_typ arg_typ = Schema.(
+      field name
+            ~typ:field_typ
+            ~args:Arg.[
+              arg "x" ~typ:arg_typ
+            ]
+            ~resolve:echo
+)
+
+type colors = Red | Green | Blue
+let color_enum     = Schema.enum ~name:"color" ~values:[Red, "RED"; Green, "GREEN"; Blue, "BLUE"]
+let color_enum_arg = Schema.Arg.enum ~name:"color" ~values:["RED", Red; "GREEN", Green; "BLUE", Blue]
+
+let person_arg = Schema.Arg.(obj ~name:"person" ~fields:Arg.[
+    arg "title" ~typ:string;
+    arg "first_name" ~typ:(non_null string);
+    arg "last_name" ~typ:(non_null string);
+  ]
+  ~coerce:(fun title first last -> (title, first, last))
+)
+
+let schema =
+  Schema.(schema ~fields:[
+      echo_field "string" string Arg.string;
+      echo_field "float" float Arg.float;
+      echo_field "int" int Arg.int;
+      echo_field "bool" bool Arg.bool;
+      echo_field "enum" color_enum color_enum_arg;
+      echo_field "id" guid Arg.guid;
+      echo_field "bool_list" (list bool) Arg.(list bool);
+      field "input_obj"
+            ~typ:(non_null string)
+            ~args:Arg.[
+              arg "x" ~typ:(non_null person_arg)
+            ]
+            ~resolve:(fun () () (title, first, last) -> first ^ " " ^ last)
+  ])

--- a/test/schema_test.ml
+++ b/test/schema_test.ml
@@ -1,4 +1,3 @@
-open Graphql
 open Test_common
 
 let suite = [

--- a/test/test.ml
+++ b/test/test.ml
@@ -3,6 +3,7 @@ let () =
     "parser",    Parser_test.suite;
     "schema",    Schema_test.suite;
     "arguments", Argument_test.suite;
+    "variables", Variable_test.suite;
     "lwt",       Lwt_test.suite;
     "async",     Async_test.suite;
   ]

--- a/test/test_common.ml
+++ b/test/test_common.ml
@@ -1,8 +1,8 @@
-let test_query schema ctx query expected =
+let test_query schema ctx ?variables query expected =
   match Graphql_parser.parse query with
   | Error err -> failwith err
   | Ok doc ->
-      let result = match Graphql.Schema.execute schema ctx doc with
+      let result = match Graphql.Schema.execute schema ctx ?variables doc with
       | Ok data -> data
       | Error err -> err
       in

--- a/test/variable_test.ml
+++ b/test/variable_test.ml
@@ -1,0 +1,48 @@
+let test_query variables = Test_common.test_query Echo_schema.schema () ~variables
+
+let suite : (string * [>`Quick] * (unit -> unit)) list = [
+  ("string variable", `Quick, fun () ->
+    test_query ["x", `String "foo"] "{ string(x: $x) }" "{\"data\":{\"string\":\"foo\"}}"
+  );
+  ("float variable", `Quick, fun () ->
+    test_query ["x", `Float 42.5] "{ float(x: $x) }" "{\"data\":{\"float\":42.5}}"
+  );
+  ("int variable", `Quick, fun () ->
+    test_query ["x", `Int 42] "{ int(x: $x) }" "{\"data\":{\"int\":42}}"
+  );
+  ("bool variable", `Quick, fun () ->
+    test_query ["x", `Bool false] "{ bool(x: $x) }" "{\"data\":{\"bool\":false}}"
+  );
+  ("enum variable", `Quick, fun () ->
+    test_query ["x", `Enum "RED"] "{ enum(x: $x) }" "{\"data\":{\"enum\":\"RED\"}}"
+  );
+  ("list variable", `Quick, fun () ->
+    test_query ["x", `List [`Bool true; `Bool false]] "{ bool_list(x: [false, true]) }" "{\"data\":{\"bool_list\":[false,true]}}"
+  );
+  ("input object variable", `Quick, fun () ->
+    let obj = `Assoc [
+      "title", `String "Mr";
+      "first_name", `String "John";
+      "last_name", `String "Doe";
+    ] in
+    test_query ["x", obj] "{ input_obj(x: {title: \"Mr\", first_name: \"John\", last_name: \"Doe\"}) }" "{\"data\":{\"input_obj\":\"John Doe\"}}"
+  );
+  ("null for optional variable", `Quick, fun () ->
+    test_query ["x", `Null]"{ string(x: $x) }" "{\"data\":{\"string\":null}}"
+  );
+  ("null for required variable", `Quick, fun () ->
+    test_query ["x", `Null] "{ input_obj(x: $x) }" "{\"errors\":[{\"message\":\"Missing required argument\"}]}"
+  );
+  ("variable coercion: single value to list", `Quick, fun () ->
+    test_query ["x", `Bool false] "{ bool_list(x: $x) }" "{\"data\":{\"bool_list\":[false]}}"
+  );
+  ("variable coercion: int to float", `Quick, fun () ->
+    test_query ["x", `Int 42] "{ float(x: $x) }" "{\"data\":{\"float\":42.0}}"
+  );
+  ("variable coercion: int to ID", `Quick, fun () ->
+    test_query ["x", `Int 42] "{ id(x: $x) }" "{\"data\":{\"id\":\"42\"}}"
+  );
+  ("variable coercion: string to ID", `Quick, fun () ->
+    test_query ["x", `String "42"] "{ id(x: $x) }" "{\"data\":{\"id\":\"42\"}}"
+  );
+]


### PR DESCRIPTION
This PR adds support for variables in query execution. The signature of `Graphql.execute` has been changed to:

```ocaml
type variables = (string * Graphql_parser.const_value) list

val execute : 'ctx schema ->
              'ctx ->
              ?variables:variables ->
              Graphql_parser.document ->
              (Yojson.Basic.json, Yojson.Basic.json) result io
```

`Yojson.Basic.json` is a subtype of `Graphql_parser.const_value`, so you can parse a JSON string and coerce it to the type `variables`:

```ocaml
let json_variables = Yojson.Basic.(from_string "{\"x\": 42}" |> Util.to_assoc) in
let variables = (json_variables :> (string * Graphql_parser.const_value) list) in
Graphql.Schema.execute schema ctx ~variables doc
```

GraphiQL screenshot:

<img width="1265" alt="ocaml-graphql-server" src="https://cloud.githubusercontent.com/assets/2518/22173954/8d1e5bbe-dfd1-11e6-9a7e-4f93d0ce2e24.png">

Depends on https://github.com/inhabitedtype/angstrom/pull/62.

resolves #5