### PR TITLE
Mutation support

### DIFF
--- a/src/graphql_intf.ml
+++ b/src/graphql_intf.ml
@@ -12,8 +12,11 @@ module type Schema = sig
 
   (** {3 Constructors } *)
 
-  val schema : fields:('ctx, unit) field list ->
-              'ctx schema
+  val schema : ?mutation_name:string ->
+               ?mutations:('ctx, unit) field list ->
+               ?query_name:string ->
+               ('ctx, unit) field list ->
+               'ctx schema
 
   val obj : ?doc:string ->
             string ->

--- a/test/async_test.ml
+++ b/test/async_test.ml
@@ -15,8 +15,7 @@ let test_query schema ctx query expected =
       Alcotest.(check string) "invalid execution result" expected (Yojson.Basic.to_string result')
   end
 
-let schema = Graphql_async.Schema.(schema
-    ~fields:[
+let schema = Graphql_async.Schema.(schema [
       field "direct_string"
         ~typ:(non_null string)
         ~args:Arg.[]

--- a/test/echo_schema.ml
+++ b/test/echo_schema.ml
@@ -24,7 +24,7 @@ let person_arg = Schema.Arg.(obj "person" ~fields:Arg.[
 )
 
 let schema =
-  Schema.(schema ~fields:[
+  Schema.(schema [
       echo_field "string" string Arg.string;
       echo_field "float" float Arg.float;
       echo_field "int" int Arg.int;

--- a/test/lwt_test.ml
+++ b/test/lwt_test.ml
@@ -14,8 +14,7 @@ let test_query schema ctx query expected =
       Alcotest.(check string) "invalid execution result" expected (Yojson.Basic.to_string result')
   end
 
-let schema = Graphql_lwt.Schema.(schema
-    ~fields:[
+let schema = Graphql_lwt.Schema.(schema [
       field "direct_string"
         ~typ:(non_null string)
         ~args:Arg.[]

--- a/test/schema_test.ml
+++ b/test/schema_test.ml
@@ -1,7 +1,10 @@
 open Test_common
 
 let suite = [
-  ("execution", `Quick, fun () ->
+  ("query", `Quick, fun () ->
     test_query Test_schema.schema () "{ users { id } }" "{\"data\":{\"users\":[{\"id\":1},{\"id\":2}]}}"
+  );
+  ("mutation", `Quick, fun () ->
+    test_query Test_schema.schema () "mutation { add_user(name: \"Charlie\", role: \"user\") { name } }" "{\"data\":{\"add_user\":[{\"name\":\"Alice\"},{\"name\":\"Bob\"},{\"name\":\"Charlie\"}]}}"
   );
 ]

--- a/test/test_schema.ml
+++ b/test/test_schema.ml
@@ -8,7 +8,7 @@ type user = {
   role : role;
 }
 
-let users = [
+let users = ref [
   { id = 1; name = "Alice"; role = Admin };
   { id = 2; name = "Bob"; role = User };
 ]
@@ -35,11 +35,25 @@ let user = Schema.(obj "user"
   ])
 )
 
-let schema = Schema.(schema 
-    ~fields:[
+let input_role = Schema.Arg.(enum "role" ~values:["user", User; "admin", Admin])
+
+let schema = Schema.(schema [
       field "users"
         ~typ:(non_null (list (non_null user)))
         ~args:Arg.[]
-        ~resolve:(fun () () -> users)
+        ~resolve:(fun () () -> !users)
+    ]
+    ~mutations:[
+      field "add_user"
+        ~typ:(non_null (list (non_null user)))
+        ~args:Arg.[
+          arg "name" ~typ:(non_null string);
+          arg "role" ~typ:(non_null input_role)
+        ]
+        ~resolve:(fun () () name role ->
+          let id = Random.int 1000000 in
+          users := List.append !users [{ id; name; role }];
+          !users
+        )
     ]
 )


### PR DESCRIPTION
[GraphiQL demo of mutation support](https://ocaml-graphql.herokuapp.com/?query=mutation%20%7B%0A%20%20add_number(number%3A%2042)%0A%7D&operationName=undefined) ✨ 

This PR implements support for mutations. The type of `Graphql.schema` has been updated from

```ocaml
(* Previous type *)
val schema : fields:('ctx, unit) field list ->
             'ctx schema
```
to
```ocaml
(* New type *)
val schema : ?mutation_name:string ->
             ?mutations:('ctx, unit) field list ->
             ?query_name:string ->
             ('ctx, unit) field list ->
             'ctx schema
```

The optional argument `~mutations` will be exposed as fields on the mutation root of the schema. Top-level mutation fields are executed serially as [described in the spec](https://facebook.github.io/graphql/#sec-Executing-Operations).

#### Example schema

```ocaml
let numbers = ref []

let schema = Schema.(schema [
      field "numbers"
        ~typ:(non_null (list (non_null int)))
        ~args:Arg.[]
        ~resolve:(fun () () -> !numbers)
    ]
    ~mutations:[
      field "add_random"
        ~typ:(non_null (list (non_null int)))
        ~args:Arg.[arg "number" ~typ:(non_null int)]
        ~resolve:(fun () () number ->
          numbers := number::!numbers;
          !numbers
        )
    ]
)
```

closes #4 