### PR TITLE
Allow recursive object types

### DIFF
--- a/src/graphql_intf.ml
+++ b/src/graphql_intf.ml
@@ -16,7 +16,7 @@ module type Schema = sig
               'ctx schema
 
   val obj : name:string ->
-            fields:('ctx, 'src) field list ->
+            fields:(('ctx, 'src option) typ -> ('ctx, 'src) field list) ->
             ('ctx, 'src option) typ
 
   module Arg : sig

--- a/test/test_schema.ml
+++ b/test/test_schema.ml
@@ -19,7 +19,7 @@ let role = Schema.enum
 
 let user = Schema.(obj
   ~name:"user"
-  ~fields:[
+  ~fields:(fun _ -> [
     field "id"
       ~typ:(non_null int)
       ~args:Arg.[]
@@ -34,7 +34,7 @@ let user = Schema.(obj
       ~typ:(non_null role)
       ~args:Arg.[]
       ~resolve:(fun () p -> p.role)
-  ]
+  ])
 )
 
 let schema = Schema.(schema 


### PR DESCRIPTION
This PR adds the ability to define a recursive object type: an object with a field that refers to the type itself. An example would be a tweet, which has many replies (also tweets).

To achieve this, the fields of an object is now a function that receives the type itself and must return a list of fields. The new type of `obj` is thus:

```ocaml
val obj : name:string ->
          fields:(('ctx, 'src option) typ -> ('ctx, 'src) field list) -> (* <-- new *)
          ('ctx, 'src option) typ
```

Example:

```ocaml
type tweet = {
  id : int;
  replies : tweet list;
}

let tweet = Schema.(obj
  ~name:"tweet"
  ~fields:(fun tweet -> [ (* <-- new *)
    field "id"
      ~typ:(non_null int)
      ~args:Arg.[]
      ~resolver:(fun ctx t -> t.id)
    ;
    field "replies"
      ~typ:(non_null (list tweet))
      ~args:Arg.[]
      ~resolver:(fun ctx t -> t.replies)
  ])
)
```

Behind the scenes, this is achieved using `let rec` and `lazy`. Thanks to @Drup for pointing me in the right direction.

closes #27 