### PR TITLE
Proper default arguments

### DIFF
--- a/examples/server.ml
+++ b/examples/server.ml
@@ -57,7 +57,7 @@ let schema = Schema.(schema
         ~typ:string
         ~args:Arg.[
           arg "config" ~typ:(non_null (obj ~name:"greeter_config" ~coerce:(fun greeting name -> (greeting, name)) ~fields:[
-            arg "greeting" ~typ:(non_null string);
+            arg' "greeting" ~typ:string ~default:"hello";
             arg "name" ~typ:(non_null string)
           ]))
         ]

--- a/src/graphql_intf.ml
+++ b/src/graphql_intf.ml
@@ -27,10 +27,14 @@ module type Schema = sig
       | [] : ('a, 'a) arg_list
       | (::) : ('b, 'c -> 'b) arg * ('a, 'b) arg_list -> ('a, 'c -> 'b) arg_list
 
-    val arg : ?default:'a option ->
-              string ->
-              typ:('a, 'b) arg_typ ->
-              ('a, 'b) arg
+    val arg : string ->
+              typ:('a, 'b -> 'a) arg_typ ->
+              ('a, 'b -> 'a) arg
+
+    val arg' : string ->
+              typ:('a, 'b option -> 'a) arg_typ ->
+              default:'b ->
+              ('a, 'b -> 'a) arg
 
     val scalar : name:string ->
                 coerce:(Graphql_parser.const_value -> ('b, string) result) ->

--- a/test/argument_test.ml
+++ b/test/argument_test.ml
@@ -46,4 +46,7 @@ let suite : (string * [>`Quick] * (unit -> unit)) list = [
   ("input coercion: string to ID", `Quick, fun () ->
     test_query "{ id(x: \"42\") }" "{\"data\":{\"id\":\"42\"}}"
   );
+  ("default arguments", `Quick, fun () ->
+    test_query "{ sum_defaults }" "{\"data\":{\"sum_defaults\":45}}"
+  )
 ]

--- a/test/echo_schema.ml
+++ b/test/echo_schema.ml
@@ -38,4 +38,12 @@ let schema =
               arg "x" ~typ:(non_null person_arg)
             ]
             ~resolve:(fun () () (title, first, last) -> first ^ " " ^ last)
+            ;
+      field "sum_defaults"
+            ~typ:int
+            ~args:Arg.[
+              arg' "x" ~typ:string ~default:"42";
+              arg' "y" ~typ:int ~default:3
+            ]
+            ~resolve:(fun () () x y -> try Some ((int_of_string x) + y) with _ -> None)
   ])


### PR DESCRIPTION
Default arguments doesn't work correctly in `master` right now. In particular, the type of `arg` isn't correct:

```ocaml
val arg : ?default:'a -> string -> ('a, 'b) arg_typ -> ('a, 'b) arg
```

Here `'a` is the "unification variable", and not the type of the content (as describe [here](https://drup.github.io/2016/08/02/difflists/)).

Specifying a default value for an argument only really makes sense if the argument is nullable, so the default value type and the argument type is interdependent. As such, two functions are now provided to construct arguments (with and without a default value):

```ocaml
val arg  : string -> typ:('a, 'b -> 'a) arg_typ -> ('a, 'b -> 'a) arg
val arg' : string -> typ:('a, 'b option -> 'a) arg_typ -> default:'b -> ('a, 'b -> 'a) arg
```

Example:

```ocaml
let schema = Schema.(schema 
    ~fields:[
      field "greeter"
        ~typ:(non_null string)
        ~args:Arg.[
            arg' "greeting" ~typ:string ~default:"hello";
            arg "name" ~typ:(non_null string)
          ]
        ~resolve:(fun ctx () greeting name ->
          Format.sprintf "%s, %s" greeting name
        )
      ;
    ]
)
```

closes #29 