### PR TITLE
Add doc field to all relevant types

### DIFF
--- a/examples/server.ml
+++ b/examples/server.ml
@@ -17,12 +17,10 @@ and bob = { id = 2; name = "Bob"; role = User; friends = [alice]}
 
 let users = [alice; bob]
 
-let role = Schema.enum
-  ~name:"role"
+let role = Schema.enum "role"
   ~values:[(User, "user"); (Admin, "admin")]
 
-let user = Schema.(obj
-  ~name:"user"
+let user = Schema.(obj "user"
   ~fields:(fun user -> [
     field "id"
       ~args:Arg.[]
@@ -56,7 +54,7 @@ let schema = Schema.(schema
       field "greeter"
         ~typ:string
         ~args:Arg.[
-          arg "config" ~typ:(non_null (obj ~name:"greeter_config" ~coerce:(fun greeting name -> (greeting, name)) ~fields:[
+          arg "config" ~typ:(non_null (obj "greeter_config" ~coerce:(fun greeting name -> (greeting, name)) ~fields:[
             arg' "greeting" ~typ:string ~default:"hello";
             arg "name" ~typ:(non_null string)
           ]))

--- a/src/graphql_intf.ml
+++ b/src/graphql_intf.ml
@@ -15,7 +15,8 @@ module type Schema = sig
   val schema : fields:('ctx, unit) field list ->
               'ctx schema
 
-  val obj : name:string ->
+  val obj : ?doc:string ->
+            string ->
             fields:(('ctx, 'src option) typ -> ('ctx, 'src) field list) ->
             ('ctx, 'src option) typ
 
@@ -27,24 +28,29 @@ module type Schema = sig
       | [] : ('a, 'a) arg_list
       | (::) : ('b, 'c -> 'b) arg * ('a, 'b) arg_list -> ('a, 'c -> 'b) arg_list
 
-    val arg : string ->
+    val arg : ?doc:string ->
+              string ->
               typ:('a, 'b -> 'a) arg_typ ->
               ('a, 'b -> 'a) arg
 
-    val arg' : string ->
-              typ:('a, 'b option -> 'a) arg_typ ->
-              default:'b ->
-              ('a, 'b -> 'a) arg
+    val arg' : ?doc:string ->
+               string ->
+               typ:('a, 'b option -> 'a) arg_typ ->
+               default:'b ->
+               ('a, 'b -> 'a) arg
 
-    val scalar : name:string ->
-                coerce:(Graphql_parser.const_value -> ('b, string) result) ->
-                ('a, 'b option -> 'a) arg_typ
+    val scalar : ?doc:string ->
+                 string ->
+                 coerce:(Graphql_parser.const_value -> ('b, string) result) ->
+                 ('a, 'b option -> 'a) arg_typ
 
-    val enum : name:string ->
-              values:(string * 'b) list ->
-              ('a, 'b option -> 'a) arg_typ
+    val enum : ?doc:string ->
+               string ->
+               values:(string * 'b) list ->
+               ('a, 'b option -> 'a) arg_typ
 
-    val obj : name:string ->
+    val obj : ?doc:string ->
+              string ->
               fields:('c, 'b) arg_list ->
               coerce:'b ->
               ('a, 'c option -> 'a) arg_typ
@@ -59,25 +65,29 @@ module type Schema = sig
     val non_null : ('a, 'b option -> 'a) arg_typ -> ('a, 'b -> 'a) arg_typ
   end
 
-  val field : string ->
+  val field : ?doc:string ->
+              string ->
               typ:('ctx, 'a) typ ->
               args:('a, 'b) Arg.arg_list ->
               resolve:('ctx -> 'src -> 'b) ->
               ('ctx, 'src) field
 
-  val io_field : string ->
-                  typ:('ctx, 'a) typ ->
-                  args:('a io, 'b) Arg.arg_list ->
-                  resolve:('ctx -> 'src -> 'b) ->
-                  ('ctx, 'src) field
+  val io_field : ?doc:string ->
+                 string ->
+                 typ:('ctx, 'a) typ ->
+                 args:('a io, 'b) Arg.arg_list ->
+                 resolve:('ctx -> 'src -> 'b) ->
+                 ('ctx, 'src) field
 
-  val enum : name:string ->
-            values:('a * string) list ->
-            ('ctx, 'a option) typ
+  val enum : ?doc:string ->
+             string ->
+             values:('a * string) list ->
+             ('ctx, 'a option) typ
 
-  val scalar : name:string ->
-              coerce:('a -> Yojson.Basic.json) ->
-              ('ctx, 'a option) typ
+  val scalar : ?doc:string ->
+               string ->
+               coerce:('a -> Yojson.Basic.json) ->
+               ('ctx, 'a option) typ
 
   val list : ('ctx, 'src) typ -> ('ctx, 'src list option) typ
 

--- a/test/echo_schema.ml
+++ b/test/echo_schema.ml
@@ -12,10 +12,10 @@ let echo_field name field_typ arg_typ = Schema.(
 )
 
 type colors = Red | Green | Blue
-let color_enum     = Schema.enum ~name:"color" ~values:[Red, "RED"; Green, "GREEN"; Blue, "BLUE"]
-let color_enum_arg = Schema.Arg.enum ~name:"color" ~values:["RED", Red; "GREEN", Green; "BLUE", Blue]
+let color_enum     = Schema.enum "color" ~values:[Red, "RED"; Green, "GREEN"; Blue, "BLUE"]
+let color_enum_arg = Schema.Arg.enum "color" ~values:["RED", Red; "GREEN", Green; "BLUE", Blue]
 
-let person_arg = Schema.Arg.(obj ~name:"person" ~fields:Arg.[
+let person_arg = Schema.Arg.(obj "person" ~fields:Arg.[
     arg "title" ~typ:string;
     arg "first_name" ~typ:(non_null string);
     arg "last_name" ~typ:(non_null string);

--- a/test/test_schema.ml
+++ b/test/test_schema.ml
@@ -13,12 +13,10 @@ let users = [
   { id = 2; name = "Bob"; role = User };
 ]
 
-let role = Schema.enum
-  ~name:"role"
+let role = Schema.enum "role"
   ~values:[(User, "user"); (Admin, "admin")]
 
-let user = Schema.(obj
-  ~name:"user"
+let user = Schema.(obj "user"
   ~fields:(fun _ -> [
     field "id"
       ~typ:(non_null int)


### PR DESCRIPTION
This PR adds a `doc` field to all relevant types, which is used for the `description` property in introspection queries. It thus allows you to document your objects, scalars, enums, etc.

Because `doc` is optional, the `name`-label has gone away for many functions, e.g.

```ocaml
(* before this PR *)
let role = Schema.enum ~name:"role" ~values:[(User, "user"); (Admin, "admin")]

(* after this PR *)
let role = Schema.enum "role" ~values:[(User, "user"); (Admin, "admin")] ~doc:"The role of a user"
```

closes #32 