### PR TITLE
Configure Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: c
+sudo: required
+install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-opam.sh
+script: bash -ex .travis-opam.sh
+env:
+  matrix:
+    - OCAML_VERSION=4.03
+    - OCAML_VERSION=4.03 DEPOPTS=lwt
+    - OCAML_VERSION=4.03 DEPOPTS=async_kernel
+    - OCAML_VERSION=4.04
+    - OCAML_VERSION=4.04 DEPOPTS=lwt
+    - OCAML_VERSION=4.04 DEPOPTS=async_kernel
+os:
+  - linux

--- a/opam
+++ b/opam
@@ -11,14 +11,28 @@ build: [
           "--with-lwt" "%{lwt:installed}%"
           "--with-async" "%{async_kernel:installed}%"
 ]
+build-test: [
+ [ "ocaml" "pkg/pkg.ml" "build" "--dev-pkg" "%{pinned}%" "--tests" "true" ]
+ [ "ocaml" "pkg/pkg.ml" "test" ]
+]
 depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}
   "angstrom" {>= "0.3.0"}
+  "ppx_deriving"
   "sexplib"
   "ppx_sexp_conv"
-  "ppx_sexp_value"
   "yojson"
   "rresult"
+  "alcotest" {test}
+  "lwt" {test}
+  "async_unix" {test}
+]
+depopts: [
+  "lwt"
+  "async_kernel"
+]
+available: [
+  ocaml-version >= "4.03.0"
 ]

--- a/src/graphql.ml
+++ b/src/graphql.ml
@@ -1,6 +1,6 @@
 module Schema = Graphql_schema.Make(struct
   type +'a t = 'a
 
-  let bind x ~f = f x
+  let bind x f = f x
   let return x = x
 end)

--- a/src/graphql_lwt.ml
+++ b/src/graphql_lwt.ml
@@ -1,6 +1,1 @@
-module Schema = Graphql_schema.Make(struct
-  type +'a t = 'a Lwt.t
-
-  let return = Lwt.return
-  let bind x ~f = Lwt.bind x f
-end)
+module Schema = Graphql_schema.Make(Lwt)

--- a/src/graphql_schema.ml
+++ b/src/graphql_schema.ml
@@ -30,7 +30,7 @@ module type IO = sig
   type +'a t
 
   val return : 'a -> 'a t
-  val bind : 'a t -> f:('a -> 'b t) -> 'b t
+  val bind : 'a t -> ('a -> 'b t) -> 'b t
 end
 
 (* Schema *)
@@ -40,7 +40,7 @@ module Make(Io : IO) = struct
   module Io = struct
     include Io
 
-    let map x ~f = bind x ~f:(fun x' -> return (f x'))
+    let map x ~f = bind x (fun x' -> return (f x'))
     let ok x = Io.return (Ok x)
     let error x = Io.return (Error x)
 
@@ -53,14 +53,14 @@ module Make(Io : IO) = struct
 
     module Result = struct
       let return x = return (Ok x)
-      let bind x f = bind x ~f:(function Ok x' -> f x' | Error _ as err -> Io.return err)
+      let bind x f = bind x (function Ok x' -> f x' | Error _ as err -> Io.return err)
       let map x ~f = map x ~f:(function Ok x' -> Ok (f x') | Error _ as err -> err)
     end
 
     let rec map_s ?(memo=[]) f = function
       | [] -> Io.return (List.rev memo)
       | x::xs ->
-          bind (f x) ~f:(fun x' -> map_s ~memo:(x'::memo) f xs)
+          bind (f x) (fun x' -> map_s ~memo:(x'::memo) f xs)
 
     let rec map_p f xs =
       List.map f xs |> all

--- a/src/graphql_schema.mli
+++ b/src/graphql_schema.mli
@@ -3,7 +3,7 @@ module type IO = sig
   type +'a t
 
   val return : 'a -> 'a t
-  val bind : 'a t -> f:('a -> 'b t) -> 'b t
+  val bind : 'a t -> ('a -> 'b t) -> 'b t
 end
 
 (* Schema *)

--- a/test/async_test.ml
+++ b/test/async_test.ml
@@ -1,6 +1,6 @@
 open Graphql
-open Async_kernel
-open Async_unix
+open Async_kernel.Std
+open Async_unix.Std
 
 let test_query schema ctx query expected =
   Thread_safe.block_on_async_exn begin fun () ->


### PR DESCRIPTION
Had to revert d73a7e5, since those changes inadvertently assumed package versions from `janestreet-bleeding` repo.