### PR TITLE
Improve parser

### DIFF
--- a/opam
+++ b/opam
@@ -19,7 +19,7 @@ depends: [
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build}
-  "angstrom" {>= "0.3.0"}
+  "angstrom" {>= "0.4.0"}
   "ppx_deriving"
   "sexplib"
   "ppx_sexp_conv"

--- a/src/graphql_parser.ml
+++ b/src/graphql_parser.ml
@@ -152,7 +152,6 @@ let dot    = char '.'
 let dash   = char '-'
 let quote  = char '"'
 
-let string_chars = ignored *> take_while1 is_name_char
 let is_name_char =
   function | '0' .. '9' | 'a' .. 'z' | 'A' .. 'Z' | '_'  -> true | _ -> false
 let name = take_while1 is_name_char
@@ -161,6 +160,15 @@ let is_number_char =
   function | '0' .. '9' | 'e' | 'E' | '.' | '-' | '+' -> true | _ -> false
 let number_chars = take_while1 is_number_char
 
+let string_chars = scan_string `Unescaped (fun state c ->
+  match state with
+  | `Escaped -> Some `Unescaped
+  | `Unescaped ->
+      match c with
+      | '\\' -> Some `Escaped
+      | '"' -> None
+      | _ -> Some `Unescaped
+)
 
 let null = string "null" *> return `Null
 

--- a/test/argument_test.ml
+++ b/test/argument_test.ml
@@ -2,7 +2,7 @@ let test_query = Test_common.test_query Echo_schema.schema ()
 
 let suite : (string * [>`Quick] * (unit -> unit)) list = [
   ("string argument", `Quick, fun () ->
-    test_query "{ string(x: \"foo\") }" "{\"data\":{\"string\":\"foo\"}}"
+    test_query "{ string(x: \"foo bar baz\") }" "{\"data\":{\"string\":\"foo bar baz\"}}"
   );
   ("float argument", `Quick, fun () ->
     test_query "{ float(x: 42.5) }" "{\"data\":{\"float\":42.5}}"

--- a/test/variable_test.ml
+++ b/test/variable_test.ml
@@ -2,7 +2,7 @@ let test_query variables = Test_common.test_query Echo_schema.schema () ~variabl
 
 let suite : (string * [>`Quick] * (unit -> unit)) list = [
   ("string variable", `Quick, fun () ->
-    test_query ["x", `String "foo"] "{ string(x: $x) }" "{\"data\":{\"string\":\"foo\"}}"
+    test_query ["x", `String "foo bar baz"] "{ string(x: $x) }" "{\"data\":{\"string\":\"foo bar baz\"}}"
   );
   ("float variable", `Quick, fun () ->
     test_query ["x", `Float 42.5] "{ float(x: $x) }" "{\"data\":{\"float\":42.5}}"


### PR DESCRIPTION
- Bumped `angstrom` to 0.4.0 to get `Angstrom.scan_state`.
- Ignored characters are handled more efficiently.
- The parser accepts more GraphQL strings, though it still doesn't check if they are valid UTF-8 or replace escaped characters or unicode characters.