### PR TITLE
Fix selection of named operations

### DIFF
--- a/graphql/test/schema_test.ml
+++ b/graphql/test/schema_test.ml
@@ -13,8 +13,32 @@ let suite = [
     let query = "{ __typename }" in
     test_query Test_schema.schema () query "{\"data\":{\"__typename\":\"query\"}}"
   );
-  ("select operation", `Quick, fun () ->
+  ("select operation (no operations)", `Quick, fun () ->
+    let query = "fragment x on y { z }" in
+    test_query Test_schema.schema () query "{\"errors\":[{\"message\":\"No operation found\"}]}"
+  );
+  ("select operation (one operation, no operation name)", `Quick, fun () ->
+    let query = "a { a: __typename }" in
+    test_query Test_schema.schema () query "{\"data\":{\"a\":\"query\"}}"
+  );
+  ("select operation (one operation, matching operation name)", `Quick, fun () ->
+    let query = "a { a: __typename }" in
+    test_query Test_schema.schema () query ~operation_name:"a" "{\"data\":{\"a\":\"query\"}}"
+  );
+  ("select operation (one operation, missing operation name)", `Quick, fun () ->
+    let query = "a { a: __typename }" in
+    test_query Test_schema.schema () query ~operation_name:"b" "{\"errors\":[{\"message\":\"Operation not found\"}]}"
+  );
+  ("select operation (multiple operations, no operation name)", `Quick, fun () ->
+    let query = "a { a: __typename } b { b: __typename }" in
+    test_query Test_schema.schema () query "{\"errors\":[{\"message\":\"Operation name required\"}]}"
+  );
+  ("select operation (multiple operations, matching operation name)", `Quick, fun () ->
     let query = "a { a: __typename } b { b: __typename }" in
     test_query Test_schema.schema () query ~operation_name:"b" "{\"data\":{\"b\":\"query\"}}"
+  );
+  ("select operation (multiple operations, missing operation name)", `Quick, fun () ->
+    let query = "a { a: __typename } b { b: __typename }" in
+    test_query Test_schema.schema () query ~operation_name:"c" "{\"errors\":[{\"message\":\"Operation not found\"}]}"
   );
 ]


### PR DESCRIPTION
Selection of named operations was previously too simple and not [according to spec](https://facebook.github.io/graphql/#sec-Execution). This PR improves the implementation and adds more tests.

resolves #46 