### PR TITLE
Update Async dependency to v0.9.0

### DIFF
--- a/opam
+++ b/opam
@@ -27,7 +27,7 @@ depends: [
   "rresult"
   "alcotest" {test}
   "lwt" {test}
-  "async_unix" {test}
+  "async_unix" {test & >= "v0.9.0"}
 ]
 depopts: [
   "lwt"

--- a/src/graphql_async.ml
+++ b/src/graphql_async.ml
@@ -1,1 +1,5 @@
-module Schema = Graphql_schema.Make(Async_kernel.Deferred)
+module Schema = Graphql_schema.Make(struct
+  include Async_kernel.Deferred
+
+  let bind x f = bind x ~f
+end)

--- a/test/async_test.ml
+++ b/test/async_test.ml
@@ -1,6 +1,6 @@
 open Graphql
-open Async_kernel.Std
-open Async_unix.Std
+open Async_kernel
+open Async_unix
 
 let test_query schema ctx query expected =
   Thread_safe.block_on_async_exn begin fun () ->


### PR DESCRIPTION
`async` v.0.9.0 updated the interface of `Async.Deferred.bind` from `'a t -> ('a -> 'b t) -> 'b t` to `'a t -> f:('a -> 'b t) -> 'b t`. This PR updates the dependency of async to v0.9.0.