### PR TITLE
Documentation and deprecation for enum values

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@ Master
 ---------------------------------
 
 - Support deprecation of fields (#53)
+- Support documentation and deprecation of enum values (#54)
 
 0.1.0 2017-05-25
 ---------------------------------

--- a/README.md
+++ b/README.md
@@ -63,9 +63,13 @@ let users = [
   { id = 2; name = "Bob"; role = User }
 ]
 
-let role = Schema.enum "role"
+let role = Schema.(enum "role"
   ~doc:"The role of a user"
-  ~values:[(User, "user"); (Admin, "admin")]
+  ~values:[
+    enum_value "USER" ~value:User;
+    enum_value "ADMIN" ~value:Admin;
+  ]
+)
 
 let user = Schema.(obj "user"
   ~doc:"A user in the system"

--- a/examples/server.ml
+++ b/examples/server.ml
@@ -17,8 +17,12 @@ and bob = { id = 2; name = "Bob"; role = User; friends = [alice]}
 
 let users = [alice; bob]
 
-let role = Schema.enum "role"
-  ~values:[(User, "user"); (Admin, "admin")]
+let role = Schema.(enum "role"
+  ~values:[
+    enum_value "USER" ~value:User ~doc:"A regular user";
+    enum_value "ADMIN" ~value:Admin ~doc:"An admin user";
+  ]
+)
 
 let user = Schema.(obj "user"
   ~fields:(fun user -> [

--- a/graphql/src/graphql_intf.ml
+++ b/graphql/src/graphql_intf.ml
@@ -10,6 +10,8 @@ module type Schema = sig
 
   type ('ctx, 'src) typ
 
+  type 'a enum_value
+
   (** {3 Constructors } *)
 
   val schema : ?mutation_name:string ->
@@ -21,6 +23,12 @@ module type Schema = sig
   type deprecated =
     | NotDeprecated
     | Deprecated of string option
+
+  val enum_value : ?doc:string ->
+                   ?deprecated:deprecated ->
+                   string ->
+                   value:'a ->
+                   'a enum_value
 
   val obj : ?doc:string ->
             string ->
@@ -53,7 +61,7 @@ module type Schema = sig
 
     val enum : ?doc:string ->
                string ->
-               values:(string * 'b) list ->
+               values:'b enum_value list ->
                ('a, 'b option -> 'a) arg_typ
 
     val obj : ?doc:string ->
@@ -90,7 +98,7 @@ module type Schema = sig
 
   val enum : ?doc:string ->
              string ->
-             values:('a * string) list ->
+             values:'a enum_value list ->
              ('ctx, 'a option) typ
 
   val scalar : ?doc:string ->

--- a/graphql/test/echo_schema.ml
+++ b/graphql/test/echo_schema.ml
@@ -12,8 +12,13 @@ let echo_field name field_typ arg_typ = Schema.(
 )
 
 type colors = Red | Green | Blue
-let color_enum     = Schema.enum "color" ~values:[Red, "RED"; Green, "GREEN"; Blue, "BLUE"]
-let color_enum_arg = Schema.Arg.enum "color" ~values:["RED", Red; "GREEN", Green; "BLUE", Blue]
+let color_enum_values = Schema.([
+  enum_value "RED" ~value:Red;
+  enum_value "GREEN" ~value:Green;
+  enum_value "BLUE" ~value:Blue
+])
+let color_enum     = Schema.enum "color" ~values:color_enum_values
+let color_enum_arg = Schema.Arg.enum "color" ~values:color_enum_values
 
 let person_arg = Schema.Arg.(obj "person" ~fields:Arg.[
     arg "title" ~typ:string;

--- a/graphql/test/test_schema.ml
+++ b/graphql/test/test_schema.ml
@@ -13,8 +13,13 @@ let users = ref [
   { id = 2; name = "Bob"; role = User };
 ]
 
-let role = Schema.enum "role"
-  ~values:[(User, "user"); (Admin, "admin")]
+let role_values = Schema.([
+  enum_value "user" ~value:User;
+  enum_value "admin" ~value:Admin;
+])
+
+let role = Schema.(enum "role" ~values:role_values)
+let input_role = Schema.Arg.(enum "role" ~values:role_values)
 
 let user = Schema.(obj "user"
   ~fields:(fun _ -> [
@@ -34,8 +39,6 @@ let user = Schema.(obj "user"
       ~resolve:(fun () p -> p.role)
   ])
 )
-
-let input_role = Schema.Arg.(enum "role" ~values:["user", User; "admin", Admin])
 
 let schema = Schema.(schema [
       field "users"


### PR DESCRIPTION
Previous an enum value was simply of type `('a * string)`, which didn't allow for documentation or deprecation. This PR introduces a proper `'a enum_value` type with the following accompanying function:

```ocaml
val enum_value : ?doc:string ->
                 ?deprecated:deprecated ->
                 string ->
                 value:'a ->
                 'a enum_value
```

This also means that `enum` now accepts a list of `enum_value`:

```ocaml
val enum : ?doc:string ->
           string ->
           values:'a enum_value list ->
           ('ctx, 'a option) typ
```

Example usage:

```ocaml
type role = User | Admin

let role = Schema.(enum "role"
  ~values:[
    enum_value "USER" ~value:User;
    enum_value "ADMIN" ~value:Admin;
  ]
)
```

⚠️ NB. This breaks backwards compatibility! ⚠️ 

resolves #51 