### PR TITLE
Parse tab as whitespace

### DIFF
--- a/graphql/src/graphql_parser.ml
+++ b/graphql/src/graphql_parser.ml
@@ -123,7 +123,7 @@ let ignored = scan_state `Whitespace (fun state c ->
       if c = '\n' then Some `Whitespace else Some `Comment
   | `Whitespace ->
       match c with
-      | ' ' | ',' | '\n' -> Some `Whitespace
+      | ' ' | ',' | '\t' | '\n' -> Some `Whitespace
       | '#' -> Some `Comment
       | _ -> None
 ) >>| fun _ -> ()


### PR DESCRIPTION
According to GraphQL spec tab should be treated as whitespace. Without this fix there is a parse error if a tab is inserted in a query.