### PR TITLE
Parser fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@
 
 - Parse tabs as whitespace (#62)
 - Move parser to separate package (#63)
+- Depend on angstrom 0.7.0 (#64)
+- Fix parsing of quoted strings (#64)
 
 0.3.0 2017-08-31
 ---------------------------------

--- a/graphql_parser.opam
+++ b/graphql_parser.opam
@@ -9,7 +9,7 @@ build: [["jbuilder" "build" "-p" name "-j" jobs]]
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 depends: [
   "jbuilder" {build}
-  "angstrom" {>= "0.4.0" & < "0.7.0"}
+  "angstrom" {>= "0.7.0"}
   "sexplib"
   "ppx_sexp_conv" {>= "0.9.0"}
   "alcotest" {test}

--- a/graphql_parser/src/graphql_parser.ml
+++ b/graphql_parser/src/graphql_parser.ml
@@ -306,4 +306,4 @@ let definition = operation_definition <|> fragment_definition
 
 let document = many1 (ignored *> definition)
 
-let parse query = Angstrom.parse_only document (`String query)
+let parse query = Angstrom.parse_string document query

--- a/graphql_parser/test/data/quoted_string.graphql
+++ b/graphql_parser/test/data/quoted_string.graphql
@@ -1,0 +1,5 @@
+query {
+  goomba(alias: "test\"") {
+    id
+  }
+}

--- a/graphql_parser/test/data/quoted_string.sexp
+++ b/graphql_parser/test/data/quoted_string.sexp
@@ -1,0 +1,10 @@
+((Operation
+  ((optype Query) (name ()) (variable_definitions ()) (directives ())
+   (selection_set
+    ((Field
+      ((alias ()) (name goomba) (arguments ((alias (String "test\""))))
+       (directives ())
+       (selection_set
+        ((Field
+          ((alias ()) (name id) (arguments ()) (directives ())
+           (selection_set ()))))))))))))

--- a/graphql_parser/test/parser_test.ml
+++ b/graphql_parser/test/parser_test.ml
@@ -20,4 +20,5 @@ let test_query_file filename () =
 let suite = [
   "introspection", `Quick, test_query_file "introspection";
   "kitchen_sink",  `Quick, test_query_file "kitchen_sink";
+  "quoted_string", `Quick, test_query_file "quoted_string";
 ]


### PR DESCRIPTION
- Depend on `angstrom` 0.7.0: https://github.com/ocaml/opam-repository/pull/10286/#issuecomment-329967555
- Fix parsing of escaped characters

closes #68 