### PR TITLE
Error handling

### DIFF
--- a/graphql-async/test/async_test.ml
+++ b/graphql-async/test/async_test.ml
@@ -33,7 +33,7 @@ let schema = Graphql_async.Schema.(schema [
       io_field "io_int"
         ~typ:(non_null int)
         ~args:Arg.[]
-        ~resolve:(fun () () -> Deferred.return 42)
+        ~resolve:(fun () () -> Deferred.return (Ok 42))
     ]
 )
 

--- a/graphql-lwt/test/lwt_test.ml
+++ b/graphql-lwt/test/lwt_test.ml
@@ -32,7 +32,7 @@ let schema = Graphql_lwt.Schema.(schema [
       io_field "io_int"
         ~typ:(non_null int)
         ~args:Arg.[]
-        ~resolve:(fun () () -> Lwt.return 42)
+        ~resolve:(fun () () -> Lwt.return (Ok 42))
     ]
 )
 

--- a/graphql/src/graphql_intf.ml
+++ b/graphql/src/graphql_intf.ml
@@ -92,7 +92,7 @@ module type Schema = sig
                  ?deprecated:deprecated ->
                  string ->
                  typ:('ctx, 'a) typ ->
-                 args:('a io, 'b) Arg.arg_list ->
+                 args:(('a, string) result io, 'b) Arg.arg_list ->
                  resolve:('ctx -> 'src -> 'b) ->
                  ('ctx, 'src) field
 

--- a/graphql/src/graphql_schema.ml
+++ b/graphql/src/graphql_schema.ml
@@ -54,6 +54,7 @@ module Make(Io : IO) = struct
     module Result = struct
       let return x = return (Ok x)
       let bind x f = bind x (function Ok x' -> f x' | Error _ as err -> Io.return err)
+      let map_error x ~f = map x ~f:(function Ok _ as ok -> ok | Error err -> Error (f err))
       let map x ~f = map x ~f:(function Ok x' -> Ok (f x') | Error _ as err -> err)
     end
 
@@ -301,10 +302,10 @@ module Make(Io : IO) = struct
       name       : string;
       doc        : string option;
       deprecated : deprecated;
-      typ        : ('ctx, 'io_out) typ;
-      args       : ('maybe_io_out, 'args) Arg.arg_list;
+      typ        : ('ctx, 'out) typ;
+      args       : ('a, 'args) Arg.arg_list;
       resolve    : 'ctx -> 'src -> 'args;
-      lift       : 'maybe_io_out -> 'io_out Io.t
+      lift       : 'a -> ('out, string) result Io.t;
     } -> ('ctx, 'src) field
   and (_, _) typ =
     | Object      : ('ctx, 'src) obj -> ('ctx, 'src option) typ
@@ -339,10 +340,10 @@ module Make(Io : IO) = struct
     o
 
   let field ?doc ?(deprecated=NotDeprecated) name ~typ ~args ~resolve =
-    Field { lift = Io.return; name; doc; deprecated; typ; args; resolve }
+    Field { name; doc; deprecated; typ; args; resolve; lift = Io.ok }
 
   let io_field ?doc ?(deprecated=NotDeprecated) name ~typ ~args ~resolve =
-    Field { lift = id; name; doc; deprecated; typ; args; resolve }
+    Field { name; doc; deprecated; typ; args; resolve; lift = id }
 
   let enum ?doc name ~values =
     Enum { name; doc; values }
@@ -528,7 +529,7 @@ module Introspection = struct
         deprecated = NotDeprecated;
         typ = NonNullable string;
         args = Arg.[];
-        lift = Io.return;
+        lift = Io.ok;
         resolve = fun _ (AnyEnumValue enum_value) -> enum_value.name;
       };
       Field {
@@ -537,7 +538,7 @@ module Introspection = struct
         deprecated = NotDeprecated;
         typ = string;
         args = Arg.[];
-        lift = Io.return;
+        lift = Io.ok;
         resolve = fun _ (AnyEnumValue enum_value) -> enum_value.doc;
       };
       Field {
@@ -546,7 +547,7 @@ module Introspection = struct
         deprecated = NotDeprecated;
         typ = NonNullable bool;
         args = Arg.[];
-        lift = Io.return;
+        lift = Io.ok;
         resolve = fun _ (AnyEnumValue enum_value) -> enum_value.deprecated <> NotDeprecated;
       };
       Field {
@@ -555,7 +556,7 @@ module Introspection = struct
         deprecated = NotDeprecated;
         typ = string;
         args = Arg.[];
-        lift = Io.return;
+        lift = Io.ok;
         resolve = fun _ (AnyEnumValue enum_value) ->
           match enum_value.deprecated with
           | Deprecated reason -> reason
@@ -574,7 +575,7 @@ module Introspection = struct
         deprecated = NotDeprecated;
         typ = NonNullable string;
         args = Arg.[];
-        lift = Io.return;
+        lift = Io.ok;
         resolve = fun _ (AnyArg arg) -> match arg with
           | Arg.DefaultArg a -> a.name
           | Arg.Arg a -> a.name
@@ -585,7 +586,7 @@ module Introspection = struct
         deprecated = NotDeprecated;
         typ = string;
         args = Arg.[];
-        lift = Io.return;
+        lift = Io.ok;
         resolve = fun _ (AnyArg arg) -> match arg with
           | Arg.DefaultArg a -> a.doc
           | Arg.Arg a -> a.doc
@@ -596,7 +597,7 @@ module Introspection = struct
         deprecated = NotDeprecated;
         typ = NonNullable __type;
         args = Arg.[];
-        lift = Io.return;
+        lift = Io.ok;
         resolve = fun _ (AnyArg arg) -> match arg with
           | Arg.DefaultArg a -> AnyArgTyp a.typ
           | Arg.Arg a -> AnyArgTyp a.typ
@@ -607,7 +608,7 @@ module Introspection = struct
         deprecated = NotDeprecated;
         typ = string;
         args = Arg.[];
-        lift = Io.return;
+        lift = Io.ok;
         resolve = fun _ (AnyArg v) -> None
       }
     ]
@@ -623,7 +624,7 @@ module Introspection = struct
         deprecated = NotDeprecated;
         typ = NonNullable __type_kind;
         args = Arg.[];
-        lift = Io.return;
+        lift = Io.ok;
         resolve = fun _ t -> match t with
           | AnyTyp (Object _) -> `Object
           | AnyTyp (List _) -> `List
@@ -642,7 +643,7 @@ module Introspection = struct
         deprecated = NotDeprecated;
         typ = string;
         args = Arg.[];
-        lift = Io.return;
+        lift = Io.ok;
         resolve = fun _ t -> match t with
           | AnyTyp (Object o) -> Some o.name
           | AnyTyp (Scalar s) -> Some s.name
@@ -658,7 +659,7 @@ module Introspection = struct
         deprecated = NotDeprecated;
         typ = string;
         args = Arg.[];
-        lift = Io.return;
+        lift = Io.ok;
         resolve = fun _ t -> match t with
           | AnyTyp (Object o) -> o.doc
           | AnyTyp (Scalar s) -> s.doc
@@ -674,7 +675,7 @@ module Introspection = struct
         deprecated = NotDeprecated;
         typ = List (NonNullable __field);
         args = Arg.[];
-        lift = Io.return;
+        lift = Io.ok;
         resolve = fun _ t -> match t with
           | AnyTyp (Object o) ->
               Some (List.map (fun f -> AnyField f) (Lazy.force o.fields))
@@ -689,7 +690,7 @@ module Introspection = struct
         deprecated = NotDeprecated;
         typ = List __type;
         args = Arg.[];
-        lift = Io.return;
+        lift = Io.ok;
         resolve = fun _ t -> match t with
           | AnyTyp (Object _) -> Some []
           | _ -> None
@@ -700,7 +701,7 @@ module Introspection = struct
         deprecated = NotDeprecated;
         typ = List __type;
         args = Arg.[];
-        lift = Io.return;
+        lift = Io.ok;
         resolve = fun _ t -> None
       };
       Field {
@@ -709,7 +710,7 @@ module Introspection = struct
         deprecated = NotDeprecated;
         typ = __type;
         args = Arg.[];
-        lift = Io.return;
+        lift = Io.ok;
         resolve = fun _ t -> match t with
           | AnyTyp (NonNullable typ) -> Some (AnyTyp typ)
           | AnyTyp (List typ) -> Some (AnyTyp typ)
@@ -723,7 +724,7 @@ module Introspection = struct
         deprecated = NotDeprecated;
         typ = List (NonNullable __input_value);
         args = Arg.[];
-        lift = Io.return;
+        lift = Io.ok;
         resolve = fun _ t -> match t with
           | AnyArgTyp (Arg.Object o) ->
               Some (args_to_list o.fields)
@@ -735,7 +736,7 @@ module Introspection = struct
         deprecated = NotDeprecated;
         typ = List (NonNullable __enum_value);
         args = Arg.[];
-        lift = Io.return;
+        lift = Io.ok;
         resolve = fun _ t -> match t with
           | AnyTyp (Enum e) -> Some (List.map (fun x -> AnyEnumValue x) e.values)
           | AnyArgTyp (Arg.Enum e) -> Some (List.map (fun x -> AnyEnumValue x) e.values)
@@ -754,7 +755,7 @@ module Introspection = struct
         deprecated = NotDeprecated;
         typ = NonNullable string;
         args = Arg.[];
-        lift = Io.return;
+        lift = Io.ok;
         resolve = fun _ f -> match f with
           | AnyField (Field f) -> f.name
           | AnyArgField (Arg.Arg a) -> a.name
@@ -766,7 +767,7 @@ module Introspection = struct
         deprecated = NotDeprecated;
         typ = string;
         args = Arg.[];
-        lift = Io.return;
+        lift = Io.ok;
         resolve = fun _ f -> match f with
           | AnyField (Field f) -> f.doc
           | AnyArgField (Arg.Arg a) -> a.doc
@@ -778,7 +779,7 @@ module Introspection = struct
         deprecated = NotDeprecated;
         typ = NonNullable (List (NonNullable __input_value));
         args = Arg.[];
-        lift = Io.return;
+        lift = Io.ok;
         resolve = fun _ f -> match f with
           | AnyField (Field f) -> args_to_list f.args
           | AnyArgField _ -> []
@@ -789,7 +790,7 @@ module Introspection = struct
         deprecated = NotDeprecated;
         typ = NonNullable __type;
         args = Arg.[];
-        lift = Io.return;
+        lift = Io.ok;
         resolve = fun _ f -> match f with
           | AnyField (Field f) -> AnyTyp f.typ
           | AnyArgField (Arg.Arg a) -> AnyArgTyp a.typ
@@ -801,7 +802,7 @@ module Introspection = struct
         deprecated = NotDeprecated;
         typ = NonNullable bool;
         args = Arg.[];
-        lift = Io.return;
+        lift = Io.ok;
         resolve = fun _ f -> match f with
           | AnyField (Field { deprecated = Deprecated _ }) -> true
           | _ -> false
@@ -812,7 +813,7 @@ module Introspection = struct
         deprecated = NotDeprecated;
         typ = string;
         args = Arg.[];
-        lift = Io.return;
+        lift = Io.ok;
         resolve = fun _ f -> match f with
           | AnyField (Field { deprecated = Deprecated reason }) -> reason
           | _ -> None
@@ -830,7 +831,7 @@ module Introspection = struct
         deprecated = NotDeprecated;
         typ = NonNullable string;
         args = Arg.[];
-        lift = Io.return;
+        lift = Io.ok;
         resolve = fun _ d -> d.name
       }
     ]
@@ -846,7 +847,7 @@ module Introspection = struct
         deprecated = NotDeprecated;
         typ = NonNullable (List (NonNullable __type));
         args = Arg.[];
-        lift = Io.return;
+        lift = Io.ok;
         resolve = fun _ s ->
           let query_types, visited = types (Object s.query) in
           match s.mutation with
@@ -859,7 +860,7 @@ module Introspection = struct
         deprecated = NotDeprecated;
         typ = NonNullable __type;
         args = Arg.[];
-        lift = Io.return;
+        lift = Io.ok;
         resolve = fun _ s -> AnyTyp (Object s.query)
       };
       Field {
@@ -868,7 +869,7 @@ module Introspection = struct
         deprecated = NotDeprecated;
         typ = __type;
         args = Arg.[];
-        lift = Io.return;
+        lift = Io.ok;
         resolve = fun _ s -> Option.map s.mutation ~f:(fun mut -> AnyTyp (Object mut))
       };
       Field {
@@ -877,7 +878,7 @@ module Introspection = struct
         deprecated = NotDeprecated;
         typ = NonNullable (List (NonNullable __directive));
         args = Arg.[];
-        lift = Io.return;
+        lift = Io.ok;
         resolve = fun _ s -> []
       }
     ]
@@ -890,7 +891,7 @@ module Introspection = struct
       deprecated = NotDeprecated;
       typ = NonNullable __schema;
       args = Arg.[];
-      lift = Io.return;
+      lift = Io.ok;
       resolve = fun _ _ -> s
     } in
     let fields = lazy (schema_field::(Lazy.force s.query.fields)) in
@@ -937,79 +938,109 @@ end
   let field_from_object : ('ctx, 'src) obj -> string -> ('ctx, 'src) field option = fun obj field_name ->
     List.find (fun (Field field) -> field.name = field_name) (Lazy.force obj.fields)
 
-  let coerce_or_null : 'a option -> ('a -> (Yojson.Basic.json, string) result Io.t) -> (Yojson.Basic.json, string) result Io.t = fun src f ->
-    match src with
-    | None -> Io.ok `Null
-    | Some src' -> f src'
+  let coerce_or_null : 'a option -> ('a -> (Yojson.Basic.json * string list, 'b) result Io.t) -> (Yojson.Basic.json * string list, 'b) result Io.t =
+    fun src f ->
+      match src with
+      | None -> Io.ok (`Null, [])
+      | Some src' -> f src'
 
-  let map order f xs =
-    match order with
-    | Serial -> Io.map_s f xs
-    | Parallel -> Io.map_p f xs
+  let map_fields_with_order = function
+    | Serial -> Io.map_s ~memo:[]
+    | Parallel -> Io.map_p
 
-  let rec present : type src. 'ctx execution_context -> src -> Graphql_parser.field -> ('ctx, src) typ -> (Yojson.Basic.json, string) result Io.t = fun ctx src query_field typ ->
-    match typ with
-    | Scalar s -> coerce_or_null src (fun x -> Io.return (Ok (s.coerce x)))
-    | List t ->
-        coerce_or_null src (fun src' ->
-          List.map (fun x -> present ctx x query_field t) src'
-          |> Io.all
-          |> Io.map ~f:List.Result.join
-          |> Io.Result.map ~f:(fun field_values -> `List field_values)
-        )
-    | NonNullable t -> present ctx (Some src) query_field t
-    | Object o ->
-        coerce_or_null src (fun src' ->
-          let fields = collect_fields ctx.fragments o query_field.selection_set in
-          resolve_fields ctx src' o fields
-        )
-    | Enum e ->
-        coerce_or_null src (fun src' ->
-          match List.find (fun enum_value -> src' == enum_value.value) e.values with
-          | Some enum_value -> Io.ok (`String enum_value.name)
-          | None -> Io.ok `Null
-        )
+  let rec present : type src. 'ctx execution_context -> src -> Graphql_parser.field -> ('ctx, src) typ -> (Yojson.Basic.json * string list, [`Argument_error of string | `Resolve_error of string]) result Io.t =
+    fun ctx src query_field typ ->
+      match typ with
+      | Scalar s -> coerce_or_null src (fun x -> Io.ok (s.coerce x, []))
+      | List t ->
+          coerce_or_null src (fun src' ->
+            List.map (fun x -> present ctx x query_field t) src'
+            |> Io.all
+            |> Io.map ~f:List.Result.join
+            |> Io.Result.map ~f:(fun xs -> (`List (List.map fst xs), List.map snd xs |> List.concat))
+          )
+      | NonNullable t -> present ctx (Some src) query_field t
+      | Object o ->
+          coerce_or_null src (fun src' ->
+            let fields = collect_fields ctx.fragments o query_field.selection_set in
+            resolve_fields ctx src' o fields
+          )
+      | Enum e ->
+          coerce_or_null src (fun src' ->
+            match List.find (fun enum_value -> src' == enum_value.value) e.values with
+            | Some enum_value -> Io.ok (`String enum_value.name, [])
+            | None -> Io.ok (`Null, [])
+          )
 
-  and resolve_field : type src. 'ctx execution_context -> src -> Graphql_parser.field -> ('ctx, src) field -> ((string * Yojson.Basic.json), string) result Io.t = fun ctx src query_field (Field field) ->
-    let open Io.Infix in
-    let name = alias_or_name query_field in
-    let resolver = field.resolve ctx.ctx src in
-    match Arg.eval_arglist ctx.variables field.args query_field.arguments resolver with
-    | Error _ as err -> Io.return err
-    | Ok tmp ->
-        field.lift tmp >>= fun resolved ->
-        present ctx resolved query_field field.typ >>|? fun value ->
-        name, value
+  and resolve_field : type src. 'ctx execution_context -> src -> Graphql_parser.field -> ('ctx, src) field -> ((string * Yojson.Basic.json) * string list, [`Argument_error of string | `Resolve_error of string]) result Io.t =
+    fun ctx src query_field (Field field) ->
+      let open Io.Infix in
+      let name = alias_or_name query_field in
+      let resolver = field.resolve ctx.ctx src in
+      match Arg.eval_arglist ctx.variables field.args query_field.arguments resolver with
+      | Ok unlifted_value ->
+          let lifted_value =
+            field.lift unlifted_value
+            |> Io.Result.map_error ~f:(fun err -> `Resolve_error err) >>=? fun resolved ->
+            present ctx resolved query_field field.typ
+          in
+          lifted_value >>| (function
+          | Ok (value, errors) ->
+              Ok ((name, value), errors)
+          | Error (`Argument_error _) as err ->
+              err
+          | Error (`Resolve_error err) as error ->
+              match field.typ with
+              | NonNullable _ ->
+                  error
+              | _ ->
+                  Ok ((name, `Null), [err])
+          )
+      | Error err ->
+          Io.error (`Argument_error err)
 
-  and resolve_fields : type src. 'ctx execution_context -> ?execution_order:execution_order -> src -> ('ctx, src) obj -> Graphql_parser.field list -> (Yojson.Basic.json, string) result Io.t = fun ctx ?execution_order:(execution_order=Parallel) src obj fields ->
-    map execution_order (fun (query_field : Graphql_parser.field) ->
-      if query_field.name = "__typename" then
-        Io.ok (alias_or_name query_field, `String obj.name)
-      else
-        match field_from_object obj query_field.name with
-        | Some field ->
-            resolve_field ctx src query_field field
-        | None ->
-            Io.ok (alias_or_name query_field, `Null)
-    ) fields
-    |> Io.map ~f:List.Result.join
-    |> Io.Result.map ~f:(fun properties -> `Assoc properties)
+  and resolve_fields : type src. 'ctx execution_context -> ?execution_order:execution_order -> src -> ('ctx, src) obj -> Graphql_parser.field list -> (Yojson.Basic.json * string list, [`Argument_error of string | `Resolve_error of string]) result Io.t =
+    fun ctx ?execution_order:(execution_order=Parallel) src obj fields ->
+      map_fields_with_order execution_order (fun (query_field : Graphql_parser.field) ->
+        if query_field.name = "__typename" then
+          Io.ok ((alias_or_name query_field, `String obj.name), [])
+        else
+          match field_from_object obj query_field.name with
+          | Some field ->
+              resolve_field ctx src query_field field
+          | None ->
+              Io.ok ((alias_or_name query_field, `Null), [])
+      ) fields
+      |> Io.map ~f:List.Result.join
+      |> Io.Result.map ~f:(fun xs -> (`Assoc (List.map fst xs), List.map snd xs |> List.concat))
 
-  let execute_operation : 'ctx schema -> 'ctx execution_context -> fragment_map -> variable_map -> Graphql_parser.operation -> (Yojson.Basic.json, string) result Io.t = fun schema ctx fragments variables operation ->
-    match operation.optype with
-    | Graphql_parser.Query ->
-        let query  = schema.query in
-        let fields = collect_fields fragments query operation.selection_set in
-        resolve_fields ctx () query fields
-    | Graphql_parser.Mutation ->
-        begin match schema.mutation with
-        | None -> Io.error "Schema is not configured for mutations"
-        | Some mut ->
-            let fields = collect_fields fragments mut operation.selection_set in
-            resolve_fields ~execution_order:Serial ctx () mut fields
-        end
-    | Graphql_parser.Subscription ->
-        Io.error "Subscription is not implemented"
+  type execute_error = [
+    | `Argument_error of string
+    | `Resolve_error of string
+    | `Validation_error of string
+    | `Mutations_not_configured
+    | `Subscriptions_not_implemented
+    | `No_operation_found
+    | `Operation_name_required
+    | `Operation_not_found
+  ]
+
+  let execute_operation : 'ctx schema -> 'ctx execution_context -> fragment_map -> variable_map -> Graphql_parser.operation -> (Yojson.Basic.json * string list, [> execute_error]) result Io.t =
+    fun schema ctx fragments variables operation ->
+      match operation.optype with
+      | Graphql_parser.Query ->
+          let query  = schema.query in
+          let fields = collect_fields fragments query operation.selection_set in
+          (resolve_fields ctx () query fields : (Yojson.Basic.json * string list, [`Argument_error of string | `Resolve_error of string]) result Io.t :> (Yojson.Basic.json * string list, [> execute_error]) result Io.t)
+      | Graphql_parser.Mutation ->
+          begin match schema.mutation with
+          | None -> Io.error `Mutations_not_configured
+          | Some mut ->
+              let fields = collect_fields fragments mut operation.selection_set in
+              (resolve_fields ~execution_order:Serial ctx () mut fields : (Yojson.Basic.json * string list, [`Argument_error of string | `Resolve_error of string]) result Io.t :> (Yojson.Basic.json * string list, [> execute_error]) result Io.t)
+          end
+      | Graphql_parser.Subscription ->
+          Io.error `Subscriptions_not_implemented
 
   let collect_fragments doc =
     List.fold_left (fun memo -> function
@@ -1026,7 +1057,8 @@ end
       Ok fragment_map
     with FragmentCycle fragment_names ->
       let cycle = String.concat ", " fragment_names in
-      Error (Format.sprintf "Fragment cycle detected: %s" cycle)
+      let msg = Format.sprintf "Fragment cycle detected: %s" cycle in
+      Error (`Validation_error msg)
 
   and validate_fragment (fragment_map : fragment_map) visited name =
     match StringMap.find name fragment_map with
@@ -1059,14 +1091,24 @@ end
   let rec select_operation ?operation_name doc =
     let operations = collect_operations doc in
     match operation_name, operations with
-    | _, [] -> Error "No operation found"
+    | _, [] -> Error `No_operation_found
     | None, [op] -> Ok op
-    | None, _::_ -> Error "Operation name required"
+    | None, _::_ -> Error `Operation_name_required
     | Some name, ops ->
         try
           Ok (List.find_exn (fun op -> op.Graphql_parser.name = Some name) ops)
         with Not_found ->
-          Error "Operation not found"
+          Error `Operation_not_found
+
+  let error_to_json err =
+    `Assoc ["message", `String err]
+
+  let error_response err =
+    `Assoc [
+      "errors", `List [
+        error_to_json err
+      ]
+    ]
 
   let execute schema ctx ?variables:(variables=[]) ?operation_name doc =
     let open Io.Infix in
@@ -1079,6 +1121,28 @@ end
       execute_operation schema' execution_ctx fragments variables op
     in
     execute' schema ctx doc >>| function
-    | Ok data   -> Ok (`Assoc ["data", data])
-    | Error err -> Error (`Assoc ["errors", `List [`Assoc ["message", `String err]]])
+    | Ok (data, []) ->
+        Ok (`Assoc ["data", data])
+    | Ok (data, errors) ->
+        let errors = List.map error_to_json errors in
+        Ok (`Assoc [
+          "data", data;
+          "errors", `List errors
+        ])
+    | Error `No_operation_found ->
+        Error (error_response "No operation found")
+    | Error `Operation_not_found ->
+        Error (error_response "Operation not found")
+    | Error `Operation_name_required ->
+        Error (error_response "Operation name required")
+    | Error `Subscriptions_not_implemented ->
+        Error (error_response "Subscriptions not implemented")
+    | Error `Mutations_not_configured ->
+        Error (error_response "Mutations not configured")
+    | Error `Validation_error err ->
+        Error (error_response err)
+    | Error (`Argument_error err)
+    | Error (`Resolve_error err) ->
+        let `Assoc errors = error_response err in
+        Error (`Assoc (("data", `Null)::errors))
 end

--- a/graphql/test/argument_test.ml
+++ b/graphql/test/argument_test.ml
@@ -68,8 +68,11 @@ let suite : (string * [>`Quick] * (unit -> unit)) list = [
   ("null for required argument", `Quick, fun () ->
     let query = "{ input_obj(x: null) }" in
     test_query query (`Assoc [
-      "errors", `List [`Assoc [
-        "message", `String "Missing required argument"]
+      "data", `Null;
+      "errors", `List [
+        `Assoc [
+          "message", `String "Missing required argument"
+        ]
       ]
     ])
   );
@@ -84,6 +87,7 @@ let suite : (string * [>`Quick] * (unit -> unit)) list = [
   ("missing required argument", `Quick, fun () ->
     let query = "{ input_obj }" in
     test_query query (`Assoc [
+      "data", `Null;
       "errors", `List [
         `Assoc [
           "message", `String "Missing required argument"

--- a/graphql/test/error_test.ml
+++ b/graphql/test/error_test.ml
@@ -1,0 +1,69 @@
+open Graphql
+open Test_common
+
+let suite = [
+  ("nullable error", `Quick, fun () ->
+    let schema = Schema.(schema [
+      io_field "nullable"
+        ~typ:int
+        ~args:Arg.[]
+        ~resolve:(fun _ () -> Error "boom")
+    ]) in
+    let query = "{ nullable }" in
+    test_query schema () query (`Assoc [
+      "data", `Assoc [
+        "nullable", `Null
+      ];
+      "errors", `List [
+        `Assoc [
+          "message", `String "boom"
+        ]
+      ]
+    ])
+  );
+  ("non-nullable error", `Quick, fun () ->
+    let schema = Schema.(schema [
+      io_field "non_nullable"
+        ~typ:(non_null int)
+        ~args:Arg.[]
+        ~resolve:(fun _ () -> Error "boom")
+    ]) in
+    let query = "{ non_nullable }" in
+    test_query schema () query (`Assoc [
+      "data", `Null;
+      "errors", `List [
+        `Assoc [
+          "message", `String "boom"
+        ]
+      ]
+    ])
+  );
+  ("nested nullable error", `Quick, fun () ->
+    let obj_with_non_nullable_field = Schema.(obj "obj"
+        ~fields:(fun _ -> [
+          io_field "non_nullable"
+            ~typ:(non_null int)
+            ~args:Arg.[]
+            ~resolve:(fun _ () -> Error "boom")
+        ]))
+    in
+    let schema = Schema.(schema [
+      field "nullable"
+        ~typ:obj_with_non_nullable_field
+        ~args:Arg.[]
+        ~resolve:(fun _ () -> Some ())
+      ])
+    in
+    let query = "{ nullable { non_nullable } }" in
+    test_query schema () query (`Assoc [
+      "data", `Assoc [
+        "nullable", `Null
+      ];
+      "errors", `List [
+        `Assoc [
+          "message", `String "boom"
+        ]
+      ]
+    ])
+  );
+]

--- a/graphql/test/jbuild
+++ b/graphql/test/jbuild
@@ -10,7 +10,8 @@
     test_schema
     variable_test
     argument_test
-    introspection_test))
+    introspection_test
+    error_test))
   (libraries (graphql alcotest))))
 
 (executables
@@ -22,4 +23,4 @@
  ((name runtest)
   (package graphql)
   (deps (test.exe))
-  (action (run ${<}))))
+  (action (run ${<} -v))))

--- a/graphql/test/test.ml
+++ b/graphql/test/test.ml
@@ -4,4 +4,5 @@ let () =
     "arguments", Argument_test.suite;
     "variables", Variable_test.suite;
     "introspection", Introspection_test.suite;
+    "errors", Error_test.suite;
   ]

--- a/graphql/test/variable_test.ml
+++ b/graphql/test/variable_test.ml
@@ -82,6 +82,7 @@ let suite : (string * [>`Quick] * (unit -> unit)) list = [
     let variables = ["x", `Null] in
     let query = "{ input_obj(x: $x) }" in
     test_query variables query (`Assoc [
+      "data", `Null;
       "errors", `List [
         `Assoc [
           "message", `String "Missing required argument"


### PR DESCRIPTION
This PR changes the type of `Schema.io_field`, such that the `resolve`-function must return a `('a, string) result`:

```ocaml
(* before *)
val io_field : ?doc:string ->
               ?deprecated:deprecated ->
               string ->
               typ:('ctx, 'out) typ ->
               args:('out io, 'args) Arg.arg_list ->
               resolve:('ctx -> 'src -> 'args) ->
               ('ctx, 'src) field

(* after *)
val io_field : ?doc:string ->
               ?deprecated:deprecated ->
               string ->
               typ:('ctx, 'out) typ ->
               args:(('out, string) result io, 'args) Arg.arg_list ->
               resolve:('ctx -> 'src -> 'args) ->
               ('ctx, 'src) field
```

Errors returned from `resolve`-functions will be exposed in the `errors`-part of the response. Nullable fields that return `Error` will be `null`, while errors from non-nullable fields will bubble up as [described in the spec](http://facebook.github.io/graphql/October2016/#sec-Errors-and-Non-Nullability).

This is a breaking change.

Addresses #61 