### PR TITLE
Use yojson for test assertions

### DIFF
--- a/graphql-lwt.opam
+++ b/graphql-lwt.opam
@@ -12,7 +12,7 @@ depends: [
   "graphql"
   "alcotest" {test}
   "lwt"
-  "cohttp-lwt-unix" {>= "0.99"}
+  "cohttp-lwt-unix" {>= "1.0.0"}
   "crunch"
 ]
 available: [

--- a/graphql-lwt/src/graphql_lwt.ml
+++ b/graphql-lwt/src/graphql_lwt.ml
@@ -21,7 +21,7 @@ module Server = struct
     Schema.execute schema ctx ~variables doc
 
   let execute_request ctx schema req body =
-    Cohttp_lwt_body.to_string body >>= fun body' ->
+    Cohttp_lwt.Body.to_string body >>= fun body' ->
     Lwt_io.printf "Body: %s\n" body';
     let json = Yojson.Basic.from_string body' in
     let query = Yojson.Basic.(json |> Util.member "query" |> Util.to_string) in

--- a/graphql-lwt/test/lwt_test.ml
+++ b/graphql-lwt/test/lwt_test.ml
@@ -1,6 +1,15 @@
 open Graphql
 open Lwt
 
+let yojson = (module struct
+  type t = Yojson.Basic.json
+
+  let pp formatter t =
+    Format.pp_print_text formatter (Yojson.Basic.pretty_to_string t)
+
+  let equal = (=)
+end : Alcotest.TESTABLE with type t = Yojson.Basic.json)
+
 let test_query schema ctx query expected =
   Lwt_main.run begin
     match Graphql_parser.parse query with
@@ -11,7 +20,7 @@ let test_query schema ctx query expected =
       | Ok data -> data
       | Error err -> err
       in
-      Alcotest.(check string) "invalid execution result" expected (Yojson.Basic.to_string result')
+      Alcotest.check yojson "invalid execution result" expected result'
   end
 
 let schema = Graphql_lwt.Schema.(schema [
@@ -29,7 +38,12 @@ let schema = Graphql_lwt.Schema.(schema [
 
 let suite = [
   ("execution", `Quick, fun () ->
-    test_query schema () "{ direct_string io_int  }" "{\"data\":{\"direct_string\":\"foo\",\"io_int\":42}}"
+    test_query schema () "{ direct_string io_int  }" (`Assoc [
+      "data", `Assoc [
+        "direct_string", `String "foo";
+        "io_int", `Int 42
+      ]
+    ])
   );
 ]
 

--- a/graphql/test/argument_test.ml
+++ b/graphql/test/argument_test.ml
@@ -2,51 +2,135 @@ let test_query = Test_common.test_query Echo_schema.schema ()
 
 let suite : (string * [>`Quick] * (unit -> unit)) list = [
   ("string argument", `Quick, fun () ->
-    test_query "{ string(x: \"foo bar baz\") }" "{\"data\":{\"string\":\"foo bar baz\"}}"
+    let query = "{ string(x: \"foo bar baz\") }" in
+    test_query query (`Assoc [
+      "data", `Assoc [
+        "string", `String "foo bar baz"
+      ]
+    ])
   );
   ("float argument", `Quick, fun () ->
-    test_query "{ float(x: 42.5) }" "{\"data\":{\"float\":42.5}}"
+    let query = "{ float(x: 42.5) }" in
+    test_query query (`Assoc [
+      "data", `Assoc [
+        "float", `Float 42.5
+      ]
+    ])
   );
   ("int argument", `Quick, fun () ->
-    test_query "{ int(x: 42) }" "{\"data\":{\"int\":42}}"
+    let query = "{ int(x: 42) }" in
+    test_query query (`Assoc [
+      "data", `Assoc [
+        "int", `Int 42
+      ]
+    ])
   );
   ("bool argument", `Quick, fun () ->
-    test_query "{ bool(x: false) }" "{\"data\":{\"bool\":false}}"
+    let query = "{ bool(x: false) }" in
+    test_query query (`Assoc [
+      "data", `Assoc [
+        "bool", `Bool false
+      ]
+    ])
   );
   ("enum argument", `Quick, fun () ->
-    test_query "{ enum(x: RED) }" "{\"data\":{\"enum\":\"RED\"}}"
+    let query = "{ enum(x: RED) }" in
+    test_query query (`Assoc [
+      "data", `Assoc [
+        "enum", `String "RED"
+      ]
+    ])
   );
   ("list argument", `Quick, fun () ->
-    test_query "{ bool_list(x: [false, true]) }" "{\"data\":{\"bool_list\":[false,true]}}"
+    let query = "{ bool_list(x: [false, true]) }" in
+    test_query query (`Assoc [
+      "data", `Assoc [
+        "bool_list", `List [`Bool false; `Bool true]
+      ]
+    ])
   );
   ("input object argument", `Quick, fun () ->
-    test_query "{ input_obj(x: {title: \"Mr\", first_name: \"John\", last_name: \"Doe\"}) }" "{\"data\":{\"input_obj\":\"John Doe\"}}"
+    let query = "{ input_obj(x: {title: \"Mr\", first_name: \"John\", last_name: \"Doe\"}) }" in
+    test_query query (`Assoc [
+      "data", `Assoc [
+        "input_obj", `String "John Doe"
+      ]
+    ])
   );
   ("null for optional argument", `Quick, fun () ->
-    test_query "{ string(x: null) }" "{\"data\":{\"string\":null}}"
+    let query = "{ string(x: null) }" in
+    test_query query (`Assoc [
+      "data", `Assoc [
+        "string", `Null
+      ]
+    ])
   );
   ("null for required argument", `Quick, fun () ->
-    test_query "{ input_obj(x: null) }" "{\"errors\":[{\"message\":\"Missing required argument\"}]}"
+    let query = "{ input_obj(x: null) }" in
+    test_query query (`Assoc [
+      "errors", `List [`Assoc [
+        "message", `String "Missing required argument"]
+      ]
+    ])
   );
   ("missing optional argument", `Quick, fun () ->
-    test_query "{ string }" "{\"data\":{\"string\":null}}"
+    let query = "{ string }" in
+    test_query query (`Assoc [
+      "data", `Assoc [
+        "string", `Null
+      ]
+    ])
   );
   ("missing required argument", `Quick, fun () ->
-    test_query "{ input_obj }" "{\"errors\":[{\"message\":\"Missing required argument\"}]}"
+    let query = "{ input_obj }" in
+    test_query query (`Assoc [
+      "errors", `List [
+        `Assoc [
+          "message", `String "Missing required argument"
+        ]
+      ]
+    ])
   );
   ("input coercion: single value to list", `Quick, fun () ->
-    test_query "{ bool_list(x: false) }" "{\"data\":{\"bool_list\":[false]}}"
+    let query = "{ bool_list(x: false) }" in
+    test_query query (`Assoc [
+      "data", `Assoc [
+        "bool_list", `List [
+          `Bool false
+        ]
+      ]
+    ])
   );
   ("input coercion: int to float", `Quick, fun () ->
-    test_query "{ float(x: 42) }" "{\"data\":{\"float\":42.0}}"
+    let query = "{ float(x: 42) }" in
+    test_query query (`Assoc [
+      "data", `Assoc [
+        "float", `Float 42.0
+      ]
+    ])
   );
   ("input coercion: int to ID", `Quick, fun () ->
-    test_query "{ id(x: 42) }" "{\"data\":{\"id\":\"42\"}}"
+    let query = "{ id(x: 42) }" in
+    test_query query (`Assoc [
+      "data", `Assoc [
+        "id", `String "42"
+      ]
+    ])
   );
   ("input coercion: string to ID", `Quick, fun () ->
-    test_query "{ id(x: \"42\") }" "{\"data\":{\"id\":\"42\"}}"
+    let query = "{ id(x: \"42\") }" in
+    test_query query (`Assoc [
+      "data", `Assoc [
+        "id", `String "42"
+      ]
+    ])
   );
   ("default arguments", `Quick, fun () ->
-    test_query "{ sum_defaults }" "{\"data\":{\"sum_defaults\":45}}"
+    let query = "{ sum_defaults }" in
+    test_query query (`Assoc [
+      "data", `Assoc [
+        "sum_defaults", `Int 45
+      ]
+    ])
   )
 ]

--- a/graphql/test/introspection_test.ml
+++ b/graphql/test/introspection_test.ml
@@ -1,5 +1,7 @@
 open Graphql
 
+let test_query schema query = Test_common.test_query schema () query
+
 let suite = [
   ("not deprecated", `Quick, fun () ->
     let schema = Schema.(schema [
@@ -9,7 +11,21 @@ let suite = [
         ~args:Arg.[]
         ~resolve:(fun _ _ -> Some "")
     ]) in
-    Test_common.test_query schema () "{ __schema { queryType { fields { isDeprecated deprecationReason } } } }" "{\"data\":{\"__schema\":{\"queryType\":{\"fields\":[{\"isDeprecated\":false,\"deprecationReason\":null}]}}}}"
+    let query = "{ __schema { queryType { fields { isDeprecated deprecationReason } } } }" in
+    test_query schema query (`Assoc [
+      "data", `Assoc [
+        "__schema", `Assoc [
+          "queryType", `Assoc [
+            "fields", `List [
+              `Assoc [
+                "isDeprecated", `Bool false;
+                "deprecationReason", `Null
+              ]
+            ]
+          ]
+        ]
+      ]
+    ])
   );
   ("default deprecation", `Quick, fun () ->
     let schema = Schema.(schema [
@@ -18,7 +34,21 @@ let suite = [
         ~args:Arg.[]
         ~resolve:(fun _ _ -> Some "")
     ]) in
-    Test_common.test_query schema () "{ __schema { queryType { fields { isDeprecated deprecationReason } } } }" "{\"data\":{\"__schema\":{\"queryType\":{\"fields\":[{\"isDeprecated\":false,\"deprecationReason\":null}]}}}}"
+    let query = "{ __schema { queryType { fields { isDeprecated deprecationReason } } } }" in
+    test_query schema query (`Assoc [
+      "data", `Assoc [
+        "__schema", `Assoc [
+          "queryType", `Assoc [
+            "fields", `List [
+              `Assoc [
+                "isDeprecated", `Bool false;
+                "deprecationReason", `Null
+              ]
+            ]
+          ]
+        ]
+      ]
+    ])
   );
   ("deprecated-without-reason", `Quick, fun () ->
     let schema = Schema.(schema [
@@ -28,7 +58,21 @@ let suite = [
         ~args:Arg.[]
         ~resolve:(fun _ _ -> Some "")
     ]) in
-    Test_common.test_query schema () "{ __schema { queryType { fields { isDeprecated deprecationReason } } } }" "{\"data\":{\"__schema\":{\"queryType\":{\"fields\":[{\"isDeprecated\":true,\"deprecationReason\":null}]}}}}"
+    let query = "{ __schema { queryType { fields { isDeprecated deprecationReason } } } }" in
+    test_query schema query (`Assoc [
+      "data", `Assoc [
+        "__schema", `Assoc [
+          "queryType", `Assoc [
+            "fields", `List [
+              `Assoc [
+                "isDeprecated", `Bool true;
+                "deprecationReason", `Null
+              ]
+            ]
+          ]
+        ]
+      ]
+    ])
   );
   ("deprecated with reason", `Quick, fun () ->
     let schema = Schema.(schema [
@@ -38,6 +82,20 @@ let suite = [
         ~args:Arg.[]
         ~resolve:(fun _ _ -> Some "")
     ]) in
-    Test_common.test_query schema () "{ __schema { queryType { fields { isDeprecated deprecationReason } } } }" "{\"data\":{\"__schema\":{\"queryType\":{\"fields\":[{\"isDeprecated\":true,\"deprecationReason\":\"deprecation reason\"}]}}}}"
+    let query = "{ __schema { queryType { fields { isDeprecated deprecationReason } } } }" in
+    test_query schema query (`Assoc [
+      "data", `Assoc [
+        "__schema", `Assoc [
+          "queryType", `Assoc [
+            "fields", `List [
+              `Assoc [
+                "isDeprecated", `Bool true;
+                "deprecationReason", `String "deprecation reason"
+              ]
+            ]
+          ]
+        ]
+      ]
+    ])
   );
 ]

--- a/graphql/test/schema_test.ml
+++ b/graphql/test/schema_test.ml
@@ -1,44 +1,109 @@
-open Test_common
+let test_query = Test_common.test_query Test_schema.schema ()
 
 let suite = [
   ("query", `Quick, fun () ->
     let query = "{ users { id } }" in
-    test_query Test_schema.schema () query "{\"data\":{\"users\":[{\"id\":1},{\"id\":2}]}}"
+    test_query query (`Assoc [
+      "data", `Assoc [
+        "users", `List [
+          `Assoc [
+            "id", `Int 1
+          ];
+          `Assoc [
+             "id", `Int 2
+          ]
+        ]
+      ]
+    ])
   );
   ("mutation", `Quick, fun () ->
     let query = "mutation { add_user(name: \"Charlie\", role: \"user\") { name } }" in
-    test_query Test_schema.schema () query "{\"data\":{\"add_user\":[{\"name\":\"Alice\"},{\"name\":\"Bob\"},{\"name\":\"Charlie\"}]}}"
+    test_query query (`Assoc [
+      "data", `Assoc [
+        "add_user", `List [
+          `Assoc [
+            "name", `String "Alice"
+          ];
+          `Assoc [
+            "name", `String "Bob"
+          ];
+          `Assoc [
+            "name", `String "Charlie"
+          ]
+        ]
+      ]
+    ])
   );
   ("__typename", `Quick, fun () ->
     let query = "{ __typename }" in
-    test_query Test_schema.schema () query "{\"data\":{\"__typename\":\"query\"}}"
+    test_query query (`Assoc [
+      "data", `Assoc [
+        "__typename", `String "query"
+      ]
+    ])
   );
   ("select operation (no operations)", `Quick, fun () ->
     let query = "fragment x on y { z }" in
-    test_query Test_schema.schema () query "{\"errors\":[{\"message\":\"No operation found\"}]}"
+    test_query query (`Assoc [
+      "errors", `List [
+        `Assoc [
+          "message", `String "No operation found"
+        ]
+      ]
+    ])
   );
   ("select operation (one operation, no operation name)", `Quick, fun () ->
     let query = "a { a: __typename }" in
-    test_query Test_schema.schema () query "{\"data\":{\"a\":\"query\"}}"
+    test_query query (`Assoc [
+      "data", `Assoc [
+        "a", `String "query"
+      ]
+    ])
   );
   ("select operation (one operation, matching operation name)", `Quick, fun () ->
     let query = "a { a: __typename }" in
-    test_query Test_schema.schema () query ~operation_name:"a" "{\"data\":{\"a\":\"query\"}}"
+    test_query query ~operation_name:"a" (`Assoc [
+      "data", `Assoc [
+        "a", `String "query"
+      ]
+    ])
   );
   ("select operation (one operation, missing operation name)", `Quick, fun () ->
     let query = "a { a: __typename }" in
-    test_query Test_schema.schema () query ~operation_name:"b" "{\"errors\":[{\"message\":\"Operation not found\"}]}"
+    test_query query ~operation_name:"b" (`Assoc [
+      "errors", `List [
+        `Assoc [
+          "message", `String "Operation not found"
+        ]
+      ]
+    ])
   );
   ("select operation (multiple operations, no operation name)", `Quick, fun () ->
     let query = "a { a: __typename } b { b: __typename }" in
-    test_query Test_schema.schema () query "{\"errors\":[{\"message\":\"Operation name required\"}]}"
+    test_query query (`Assoc [
+      "errors", `List [
+        `Assoc [
+          "message", `String "Operation name required"
+        ]
+      ]
+    ])
   );
   ("select operation (multiple operations, matching operation name)", `Quick, fun () ->
     let query = "a { a: __typename } b { b: __typename }" in
-    test_query Test_schema.schema () query ~operation_name:"b" "{\"data\":{\"b\":\"query\"}}"
+    test_query query ~operation_name:"b" (`Assoc [
+      "data", `Assoc [
+        "b", `String "query"
+      ]
+    ])
   );
   ("select operation (multiple operations, missing operation name)", `Quick, fun () ->
     let query = "a { a: __typename } b { b: __typename }" in
-    test_query Test_schema.schema () query ~operation_name:"c" "{\"errors\":[{\"message\":\"Operation not found\"}]}"
+    test_query query ~operation_name:"c" (`Assoc [
+      "errors", `List [
+        `Assoc [
+          "message", `String "Operation not found"
+        ]
+      ]
+    ])
   );
 ]

--- a/graphql/test/test_common.ml
+++ b/graphql/test/test_common.ml
@@ -1,3 +1,12 @@
+let yojson = (module struct
+  type t = Yojson.Basic.json
+
+  let pp formatter t =
+    Format.pp_print_text formatter (Yojson.Basic.pretty_to_string t)
+
+  let equal = (=)
+end : Alcotest.TESTABLE with type t = Yojson.Basic.json)
+
 let test_query schema ctx ?variables ?operation_name query expected =
   match Graphql_parser.parse query with
   | Error err -> failwith err
@@ -6,4 +15,4 @@ let test_query schema ctx ?variables ?operation_name query expected =
       | Ok data -> data
       | Error err -> err
       in
-      Alcotest.(check string) "invalid execution result" expected (Yojson.Basic.to_string result)
+      Alcotest.check yojson "invalid execution result" expected result

--- a/graphql/test/variable_test.ml
+++ b/graphql/test/variable_test.ml
@@ -2,22 +2,60 @@ let test_query variables = Test_common.test_query Echo_schema.schema () ~variabl
 
 let suite : (string * [>`Quick] * (unit -> unit)) list = [
   ("string variable", `Quick, fun () ->
-    test_query ["x", `String "foo bar baz"] "{ string(x: $x) }" "{\"data\":{\"string\":\"foo bar baz\"}}"
+    let variables = ["x", `String "foo bar baz"] in
+    let query = "{ string(x: $x) }" in
+    test_query variables query (`Assoc [
+      "data", `Assoc [
+        "string", `String "foo bar baz"
+      ]
+    ])
   );
   ("float variable", `Quick, fun () ->
-    test_query ["x", `Float 42.5] "{ float(x: $x) }" "{\"data\":{\"float\":42.5}}"
+    let variables = ["x", `Float 42.5] in
+    let query = "{ float(x: $x) }" in
+    test_query variables query (`Assoc [
+      "data", `Assoc [
+        "float", `Float 42.5
+      ]
+    ])
   );
   ("int variable", `Quick, fun () ->
-    test_query ["x", `Int 42] "{ int(x: $x) }" "{\"data\":{\"int\":42}}"
+    let variables = ["x", `Int 42] in
+    let query = "{ int(x: $x) }" in
+    test_query variables query (`Assoc [
+      "data", `Assoc [
+        "int", `Int 42
+      ]
+    ])
   );
   ("bool variable", `Quick, fun () ->
-    test_query ["x", `Bool false] "{ bool(x: $x) }" "{\"data\":{\"bool\":false}}"
+    let variables = ["x", `Bool false] in
+    let query = "{ bool(x: $x) }" in
+    test_query variables query (`Assoc [
+      "data", `Assoc [
+        "bool", `Bool false
+      ]
+    ])
   );
   ("enum variable", `Quick, fun () ->
-    test_query ["x", `Enum "RED"] "{ enum(x: $x) }" "{\"data\":{\"enum\":\"RED\"}}"
+    let variables = ["x", `Enum "RED"] in
+    let query = "{ enum(x: $x) }" in
+    test_query variables query (`Assoc [
+      "data", `Assoc [
+        "enum", `String "RED"
+      ]
+    ])
   );
   ("list variable", `Quick, fun () ->
-    test_query ["x", `List [`Bool true; `Bool false]] "{ bool_list(x: [false, true]) }" "{\"data\":{\"bool_list\":[false,true]}}"
+    let variables = ["x", `List [`Bool true; `Bool false]] in
+    let query = "{ bool_list(x: [false, true]) }" in
+    test_query variables query (`Assoc [
+      "data", `Assoc [
+        "bool_list", `List [
+          `Bool false; `Bool true
+        ]
+      ]
+    ])
   );
   ("input object variable", `Quick, fun () ->
     let obj = `Assoc [
@@ -25,24 +63,68 @@ let suite : (string * [>`Quick] * (unit -> unit)) list = [
       "first_name", `String "John";
       "last_name", `String "Doe";
     ] in
-    test_query ["x", obj] "{ input_obj(x: {title: \"Mr\", first_name: \"John\", last_name: \"Doe\"}) }" "{\"data\":{\"input_obj\":\"John Doe\"}}"
+    let variables = ["x", obj] in
+    let query = "{ input_obj(x: {title: \"Mr\", first_name: \"John\", last_name: \"Doe\"}) }" in
+    test_query variables query (`Assoc [
+      "data", `Assoc [
+        "input_obj", `String "John Doe"
+      ]
+    ])
   );
   ("null for optional variable", `Quick, fun () ->
-    test_query ["x", `Null]"{ string(x: $x) }" "{\"data\":{\"string\":null}}"
+    test_query ["x", `Null]"{ string(x: $x) }" (`Assoc [
+      "data", `Assoc [
+        "string", `Null
+      ]
+    ])
   );
   ("null for required variable", `Quick, fun () ->
-    test_query ["x", `Null] "{ input_obj(x: $x) }" "{\"errors\":[{\"message\":\"Missing required argument\"}]}"
+    let variables = ["x", `Null] in
+    let query = "{ input_obj(x: $x) }" in
+    test_query variables query (`Assoc [
+      "errors", `List [
+        `Assoc [
+          "message", `String "Missing required argument"
+        ]
+      ]
+    ])
   );
   ("variable coercion: single value to list", `Quick, fun () ->
-    test_query ["x", `Bool false] "{ bool_list(x: $x) }" "{\"data\":{\"bool_list\":[false]}}"
+    let variables = ["x", `Bool false] in
+    let query = "{ bool_list(x: $x) }" in
+    test_query variables query (`Assoc [
+      "data", `Assoc [
+        "bool_list", `List [
+          `Bool false
+        ]
+      ]
+    ])
   );
   ("variable coercion: int to float", `Quick, fun () ->
-    test_query ["x", `Int 42] "{ float(x: $x) }" "{\"data\":{\"float\":42.0}}"
+    let variables = ["x", `Int 42] in
+    let query = "{ float(x: $x) }" in
+    test_query variables query (`Assoc [
+      "data", `Assoc [
+        "float", `Float 42.0
+      ]
+    ])
   );
   ("variable coercion: int to ID", `Quick, fun () ->
-    test_query ["x", `Int 42] "{ id(x: $x) }" "{\"data\":{\"id\":\"42\"}}"
+    let variables = ["x", `Int 42] in
+    let query = "{ id(x: $x) }" in
+    test_query variables query (`Assoc [
+      "data", `Assoc [
+        "id", `String "42"
+      ]
+    ])
   );
   ("variable coercion: string to ID", `Quick, fun () ->
-    test_query ["x", `String "42"] "{ id(x: $x) }" "{\"data\":{\"id\":\"42\"}}"
+    let variables = ["x", `String "42"] in
+    let query = "{ id(x: $x) }" in
+    test_query variables query (`Assoc [
+      "data", `Assoc [
+        "id", `String "42"
+      ]
+    ])
   );
 ]


### PR DESCRIPTION
This PR is just a bit of housekeeping. Rather than compare strings in the test assertions, use `Yojson.Basic.json` values instead.

Also includes an update to depend on `cohttp-lwt-unix` version 1.0.0.