### PR TITLE
Make custom argument types generalizable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - Move parser to separate package (#63)
 - Depend on angstrom 0.7.0 (#64)
 - Fix parsing of quoted strings (#64)
+- Make custom argument types generalizable (#65)
 
 0.3.0 2017-08-31
 ---------------------------------

--- a/graphql/src/graphql_intf.ml
+++ b/graphql/src/graphql_intf.ml
@@ -36,48 +36,48 @@ module type Schema = sig
             ('ctx, 'src option) typ
 
   module Arg : sig
-    type (_, _) arg
-    type (_, _) arg_typ
+    type _ arg
+    type _ arg_typ
 
     type (_, _) arg_list =
       | [] : ('a, 'a) arg_list
-      | (::) : ('b, 'c -> 'b) arg * ('a, 'b) arg_list -> ('a, 'c -> 'b) arg_list
+      | (::) : 'a arg * ('b, 'c) arg_list -> ('b, 'a -> 'c) arg_list
 
     val arg : ?doc:string ->
               string ->
-              typ:('a, 'b -> 'a) arg_typ ->
-              ('a, 'b -> 'a) arg
+              typ:'a arg_typ ->
+              'a arg
 
     val arg' : ?doc:string ->
                string ->
-               typ:('a, 'b option -> 'a) arg_typ ->
-               default:'b ->
-               ('a, 'b -> 'a) arg
+               typ:'a option arg_typ ->
+               default:'a ->
+               'a arg
 
     val scalar : ?doc:string ->
                  string ->
-                 coerce:(Graphql_parser.const_value -> ('b, string) result) ->
-                 ('a, 'b option -> 'a) arg_typ
+                 coerce:(Graphql_parser.const_value -> ('a, string) result) ->
+                 'a option arg_typ
 
     val enum : ?doc:string ->
                string ->
-               values:'b enum_value list ->
-               ('a, 'b option -> 'a) arg_typ
+               values:'a enum_value list ->
+               'a option arg_typ
 
     val obj : ?doc:string ->
               string ->
-              fields:('c, 'b) arg_list ->
+              fields:('a, 'b) arg_list ->
               coerce:'b ->
-              ('a, 'c option -> 'a) arg_typ
+              'a option arg_typ
 
     (* Argument constructors *)
-    val int : ('a, int option -> 'a) arg_typ
-    val string : ('a, string option -> 'a) arg_typ
-    val bool : ('a, bool option -> 'a) arg_typ
-    val float : ('a, float option -> 'a) arg_typ
-    val guid : ('a, string option -> 'a) arg_typ
-    val list : ('a, 'b -> 'a) arg_typ -> ('a, 'b list option -> 'a) arg_typ
-    val non_null : ('a, 'b option -> 'a) arg_typ -> ('a, 'b -> 'a) arg_typ
+    val int : int option arg_typ
+    val string : string option arg_typ
+    val bool : bool option arg_typ
+    val float : float option arg_typ
+    val guid : string option arg_typ
+    val list : 'a arg_typ -> 'a list option arg_typ
+    val non_null : 'a option arg_typ -> 'a arg_typ
   end
 
   val field : ?doc:string ->

--- a/graphql/src/graphql_schema.ml
+++ b/graphql/src/graphql_schema.ml
@@ -103,40 +103,40 @@ module Make(Io : IO) = struct
   module Arg = struct
     open Rresult
 
-    type (_, _) arg_typ =
+    type _ arg_typ =
       | Scalar : {
           name   : string;
           doc    : string option;
-          coerce : Graphql_parser.const_value -> ('b, string) result;
-        } -> ('a, 'b option -> 'a) arg_typ
+          coerce : Graphql_parser.const_value -> ('a, string) result;
+        } -> 'a option arg_typ
       | Object : {
           name   : string;
           doc    : string option;
           fields : ('a, 'b) arg_list;
           coerce : 'b;
-        } -> ('c, 'a option -> 'c) arg_typ
+        } -> 'a option arg_typ
       | Enum : {
           name   : string;
           doc    : string option;
-          values : 'b enum_value list;
-        } -> ('a, 'b option -> 'a) arg_typ
-      | List : ('a, 'b -> 'a) arg_typ -> ('a, 'b list option -> 'a) arg_typ
-      | NonNullable : ('a, 'b option -> 'a) arg_typ -> ('a, 'b -> 'a) arg_typ
-    and ('a, 'b) arg =
+          values : 'a enum_value list;
+        } -> 'a option arg_typ
+      | List : 'a arg_typ -> 'a list option arg_typ
+      | NonNullable : 'a option arg_typ -> 'a arg_typ
+    and _ arg =
       | Arg : {
           name : string;
           doc : string option;
-          typ : ('a, 'b) arg_typ;
-        } -> ('a, 'b) arg
+          typ : 'a arg_typ;
+        } -> 'a arg
       | DefaultArg : {
           name : string;
           doc : string option;
-          typ : ('a, 'b option -> 'a) arg_typ;
-          default : 'b;
-        } -> ('a, 'b -> 'a) arg
+          typ : 'a option arg_typ;
+          default : 'a;
+        } -> 'a arg
     and (_, _) arg_list =
       | [] : ('a, 'a) arg_list
-      | (::) : ('b, 'c -> 'b) arg * ('a, 'b) arg_list -> ('a, 'c -> 'b) arg_list
+      | (::) : 'a arg * ('b, 'c) arg_list -> ('b, 'a -> 'c) arg_list
 
     let arg ?doc name ~typ =
       Arg { name; doc; typ }
@@ -230,7 +230,7 @@ module Make(Io : IO) = struct
               eval_arglist variable_map arglist' key_values (f coerced)
             with StringMap.Missing_key key -> Error (Format.sprintf "Missing variable `%s`" key)
 
-    and eval_arg : type a b. variable_map -> (a, b -> a) arg_typ -> Graphql_parser.const_value option -> (b, string) result = fun variable_map typ value ->
+    and eval_arg : type a. variable_map ->  a arg_typ -> Graphql_parser.const_value option -> (a, string) result = fun variable_map typ value ->
       match (typ, value) with
       | NonNullable _, None -> Error "Missing required argument"
       | NonNullable _, Some `Null -> Error "Missing required argument"
@@ -260,7 +260,7 @@ module Make(Io : IO) = struct
               List.Result.all (eval_arg variable_map typ) option_values >>| fun coerced ->
               Some coerced
           | value -> eval_arg variable_map typ (Some value) >>| fun coerced ->
-              (Some [coerced] : b)
+              (Some [coerced] : a)
           end
       | NonNullable typ, value ->
           eval_arg variable_map typ value >>= (function
@@ -391,11 +391,11 @@ module Introspection = struct
   (* any_typ, any_field and any_arg hide type parameters to avoid scope escaping errors *)
   type any_typ =
     | AnyTyp : (_, _) typ -> any_typ
-    | AnyArgTyp : (_, _) Arg.arg_typ -> any_typ
+    | AnyArgTyp : _ Arg.arg_typ -> any_typ
   type any_field =
     | AnyField : (_, _) field -> any_field
-    | AnyArgField : (_, _) Arg.arg -> any_field
-  type any_arg = AnyArg : (_, _) Arg.arg -> any_arg
+    | AnyArgField : _ Arg.arg -> any_field
+  type any_arg = AnyArg : _ Arg.arg -> any_arg
   type any_enum_value = AnyEnumValue : _ enum_value -> any_enum_value
 
   let unless_visited (result, visited) name f =
@@ -427,7 +427,7 @@ module Introspection = struct
           in
           List.fold_left reducer (result', visited') (Lazy.force o.fields)
         )
-  and arg_types : type a b. any_typ list -> (a, b) Arg.arg_typ -> any_typ list = fun memo argtyp ->
+  and arg_types : type a. any_typ list -> a Arg.arg_typ -> any_typ list = fun memo argtyp ->
     match argtyp with
     | Arg.Scalar _ as scalar -> (AnyArgTyp scalar)::memo
     | Arg.Enum _ as enum -> (AnyArgTyp enum)::memo


### PR DESCRIPTION
Previously argument types, `Schema.Arg.arg_typ`, was not generalizable, i.e. they could not be used in multiple contexts. Example that didn't work prior to this PR:

```ocaml
let silly_int = Schema.Arg.scalar "SillyInt"
  ~coerce:(function
    | `Int n -> Ok (n+1)
    | _ -> Error "Invalid silly int"
  )

let schema = Schema.(schema [
  field "foo"
    ~typ:(non_null int)
    ~args:Arg.[arg "a" ~typ:(non_null silly_int)]
    ~resolve:(fun _ () a -> a)
  ;
  field "bar"
    ~typ:(non_null string)
    ~args:Arg.[arg "a" ~typ:(non_null silly_int)]  (* <-- this would fail! *)
    ~resolve:(fun _ () a -> string_of_int a)
])
```

This was an artifact of the clumsy way `Schema.Arg.arg_typ` was defined. With this PR, the above example works. Thanks to @drup for the suggested simplification.