### PR TITLE
Fix fragment cycle check

### DIFF
--- a/graphql/src/graphql_schema.ml
+++ b/graphql/src/graphql_schema.ml
@@ -1021,7 +1021,7 @@ end
   let rec validate_fragments fragment_map =
     try
       StringMap.iter (fun name _ ->
-        ignore (validate_fragment fragment_map StringSet.empty name)
+        validate_fragment fragment_map StringSet.empty name
       ) fragment_map;
       Ok fragment_map
     with FragmentCycle fragment_names ->
@@ -1030,19 +1030,19 @@ end
 
   and validate_fragment (fragment_map : fragment_map) visited name =
     match StringMap.find name fragment_map with
-    | None -> visited
+    | None -> ()
     | Some fragment when StringSet.mem fragment.name visited ->
         raise (FragmentCycle (StringSet.elements visited))
     | Some fragment ->
         let visited' = StringSet.add fragment.name visited in
-        List.fold_left (validate_fragment_selection fragment_map) visited' fragment.selection_set
+        List.iter (validate_fragment_selection fragment_map visited') fragment.selection_set
 
   and validate_fragment_selection fragment_map visited selection =
     match selection with
     | Graphql_parser.Field field ->
-        List.fold_left (validate_fragment_selection fragment_map) visited field.selection_set
+        List.iter (validate_fragment_selection fragment_map visited) field.selection_set
     | InlineFragment inline_fragment ->
-        List.fold_left (validate_fragment_selection fragment_map) visited inline_fragment.selection_set
+        List.iter (validate_fragment_selection fragment_map visited) inline_fragment.selection_set
     | FragmentSpread fragment_spread ->
         validate_fragment fragment_map visited fragment_spread.name
 

--- a/graphql/test/schema_test.ml
+++ b/graphql/test/schema_test.ml
@@ -132,4 +132,106 @@ let suite = [
       ]
     ])
   );
+  ("introspection query should be accepted", `Quick, fun () ->
+    let query = "
+      query IntrospectionQuery {
+        __schema {
+          queryType { name }
+          mutationType { name }
+          subscriptionType { name }
+          types {
+            ...FullType
+          }
+          directives {
+            name
+            description
+            locations
+            args {
+              ...InputValue
+            }
+          }
+        }
+      }
+
+      fragment FullType on __Type {
+        kind
+        name
+        description
+        fields(includeDeprecated: true) {
+          name
+          description
+          args {
+            ...InputValue
+          }
+          type {
+            ...TypeRef
+          }
+          isDeprecated
+          deprecationReason
+        }
+        inputFields {
+          ...InputValue
+        }
+        interfaces {
+          ...TypeRef
+        }
+        enumValues(includeDeprecated: true) {
+          name
+          description
+          isDeprecated
+          deprecationReason
+        }
+        possibleTypes {
+          ...TypeRef
+        }
+      }
+
+      fragment InputValue on __InputValue {
+        name
+        description
+        type { ...TypeRef }
+        defaultValue
+      }
+
+      fragment TypeRef on __Type {
+        kind
+        name
+        ofType {
+          kind
+          name
+          ofType {
+            kind
+            name
+            ofType {
+              kind
+              name
+              ofType {
+                kind
+                name
+                ofType {
+                  kind
+                  name
+                  ofType {
+                    kind
+                    name
+                    ofType {
+                      kind
+                      name
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    " in
+    match Graphql_parser.parse query with
+    | Error err -> failwith err
+    | Ok doc ->
+        begin match Graphql.Schema.execute Test_schema.schema () doc with
+        | Ok _ -> ()
+        | Error err -> failwith (Yojson.Basic.pretty_to_string err)
+        end
+  );
 ]


### PR DESCRIPTION
The fragment cycle check introduced in #78 was flawed: the visited-set was reused across fields in the same selection set, which is incorrect. With this PR, the visited-set is only reused when traversing deeper in the query.