### PR TITLE
Add cohttp-lwt-unix as examples' dune dependecy

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To run a sample GraphQL server also serving GraphiQL, do the following:
 
 ```bash
 opam install graphql-lwt jbuilder
-git checkout git@github.com/andreas/ocaml-graphql-server.git
+git clone git@github.com/andreas/ocaml-graphql-server.git
 cd ocaml-graphql-server
 cd examples
 jbuilder build server.exe

--- a/examples/jbuild
+++ b/examples/jbuild
@@ -1,7 +1,7 @@
 (jbuild_version 1)
 
 (executable
- ((libraries (cohttp-lwt-unix cohttp.lwt graphql-lwt yojson))
+ ((libraries (cohttp.lwt graphql-lwt yojson))
   (name server)))
 
 (alias

--- a/examples/jbuild
+++ b/examples/jbuild
@@ -1,7 +1,7 @@
 (jbuild_version 1)
 
 (executable
- ((libraries (cohttp.lwt graphql-lwt yojson))
+ ((libraries (cohttp-lwt-unix cohttp.lwt graphql-lwt yojson))
   (name server)))
 
 (alias

--- a/examples/server.ml
+++ b/examples/server.ml
@@ -1,6 +1,4 @@
 open Lwt
-module C = Cohttp_lwt_unix
-
 open Graphql_lwt
 
 type role = User | Admin


### PR DESCRIPTION
**NOOB ALERT: This might be pretty stupid change as I don't have almost any experience with OCaml ecosystem. If it's the case - close this.**

Cohttp_lwt_unix is dependency used in examples but was missing in
jbuild file. This commit should resolve potential issues with
unbounded modules while attempting to build examples on systems on
which this lib wasn't already installed.