### PR TITLE
Pass HTTP request to ctx function in Graphql_lwt.Server.start

### DIFF
--- a/examples/server.ml
+++ b/examples/server.ml
@@ -70,5 +70,5 @@ let schema = Schema.(schema [
 )
 
 let () =
-  Server.start ~ctx:(fun () -> ()) schema
+  Server.start ~ctx:(fun req -> ()) schema
   |> Lwt_main.run

--- a/graphql-lwt/src/graphql_lwt.ml
+++ b/graphql-lwt/src/graphql_lwt.ml
@@ -43,7 +43,7 @@ module Server = struct
       match req.meth, path_parts with
       | `GET,  ["graphql"]       -> static_file_response "index.html"
       | `GET,  ["graphql"; path] -> static_file_response path
-      | `POST, ["graphql"]       -> execute_request (mk_context ()) schema req body
+      | `POST, ["graphql"]       -> execute_request (mk_context req) schema req body
       | _ -> C.Server.respond_string ~status:`Not_found ~body:"" ()
 
   let start ?(port=8080) ~ctx schema =

--- a/graphql-lwt/src/graphql_lwt.mli
+++ b/graphql-lwt/src/graphql_lwt.mli
@@ -4,5 +4,5 @@ module Schema : sig
 end
 
 module Server : sig
-  val start : ?port:int -> ctx:(unit -> 'ctx) -> 'ctx Schema.schema -> unit Lwt.t
+  val start : ?port:int -> ctx:(Cohttp.Request.t -> 'ctx) -> 'ctx Schema.schema -> unit Lwt.t
 end


### PR DESCRIPTION
This PR changes the type of `Graphql_lwt.Server.start`:

```ocaml
(* Before this PR *)
val start : ?port:int -> ctx:(unit -> 'ctx) -> 'ctx Schema.schema -> unit Lwt.t

(* After this PR *)
val start : ?port:int -> ctx:(Cohttp.Request.t -> 'ctx) -> 'ctx Schema.schema -> unit Lwt.t
```

This allows library users to construct a context that depends on the incoming HTTP request, e.g. cookies, headers, etc. Related to `https://github.com/andreas/ocaml-graphql-server/issues/43#issuecomment-378058396`.