### PR TITLE
Support GET requests

### DIFF
--- a/graphql-lwt/src/graphql_lwt.ml
+++ b/graphql-lwt/src/graphql_lwt.ml
@@ -21,11 +21,27 @@ module Server = struct
     Schema.execute schema ctx ~variables doc
 
   let execute_request ctx schema req body =
-    Cohttp_lwt.Body.to_string body >>= fun body' ->
-    Lwt_io.printf "Body: %s\n" body';
-    let json = Yojson.Basic.from_string body' in
-    let query = Yojson.Basic.(json |> Util.member "query" |> Util.to_string) in
-    let variables = try Yojson.Basic.Util.(json |> member "variables" |> to_assoc) with _ -> [] in
+    let uri = Cohttp.Request.uri req in
+    (* Use query params if the "query" query param exists; otherwise use the
+       body of the request *)
+    (match Uri.get_query_param uri "query" with
+      | Some query ->
+        Cohttp_lwt.Body.drain_body body >|= fun () ->
+        let variables =
+          match Uri.get_query_param uri "variables" with
+          | Some json ->
+            Yojson.Basic.(from_string json |> Util.to_assoc)
+          | None -> []
+        in
+        query, variables
+      | None ->
+        Cohttp_lwt.Body.to_string body >|= fun body' ->
+        Lwt_io.printf "Body: %s\n" body';
+        let json = Yojson.Basic.from_string body' in
+        let query = Yojson.Basic.(json |> Util.member "query" |> Util.to_string) in
+        let variables = try Yojson.Basic.Util.(json |> member "variables" |> to_assoc) with _ -> [] in
+        query, variables)
+    >>= fun (query, variables) ->
     Lwt_io.printf "Query: %s\n" query;
     let result = execute_query ctx schema (variables :> (string * Graphql_parser.const_value) list) query in
     result >>= function
@@ -40,10 +56,20 @@ module Server = struct
     Lwt_io.printf "Req: %s\n" req.resource;
     let req_path = Cohttp.Request.uri req |> Uri.path in
     let path_parts = Str.(split (regexp "/") req_path) in
-      match req.meth, path_parts with
-      | `GET,  ["graphql"]       -> static_file_response "index.html"
-      | `GET,  ["graphql"; path] -> static_file_response path
-      | `POST, ["graphql"]       -> execute_request (mk_context req) schema req body
+    let accept_html =
+      let headers = Cohttp.Request.headers req in
+      let accept = Cohttp.Header.get headers "accept" in
+      match accept with
+      | None -> false
+      | Some str ->
+        String.split_on_char ',' str
+        |> List.exists ((=) "text/html")
+    in
+      match req.meth, path_parts, accept_html with
+      | `GET,  ["graphql"], true    -> static_file_response "index.html"
+      | `GET,  ["graphql"; path], _ -> static_file_response path
+      | `GET,  ["graphql"], false
+      | `POST, ["graphql"], _       -> execute_request (mk_context req) schema req body
       | _ -> C.Server.respond_string ~status:`Not_found ~body:"" ()
 
   let start ?(port=8080) ~ctx schema =


### PR DESCRIPTION
Previously we were serving the GraphiQL page for all GET requests, but
we should only do that if we receive `Accept: text/html`.

We also ignored the `query` query param, even though it's the required
way to handle GET requests, and is recommended to be supported for
POST requests.

See: http://graphql.org/learn/serving-over-http/#get-request

Fixes #89 