### PR TITLE
Abstract types: Update interface list

### DIFF
--- a/graphql/src/graphql_intf.ml
+++ b/graphql/src/graphql_intf.ml
@@ -110,6 +110,30 @@ module type Schema = sig
 
   val non_null : ('ctx, 'src option) typ -> ('ctx, 'src) typ
 
+  type ('ctx, 'a) abstract_value
+  type ('ctx, 'a) abstract_typ = ('ctx, ('ctx, 'a) abstract_value option) typ
+
+  val union : ?doc:string ->
+              string ->
+              ('ctx, 'a) abstract_typ
+
+  type abstract_field
+  val abstract_field : ?doc:string ->
+                       ?deprecated:deprecated ->
+                       string ->
+                       typ:(_, 'a) typ ->
+                       args:('a, _) Arg.arg_list ->
+                       abstract_field
+
+  val interface : ?doc:string ->
+                  string ->
+                  fields:(('ctx, 'a) abstract_typ -> abstract_field list) ->
+                  ('ctx, 'a) abstract_typ
+
+  val add_type : ('ctx, 'a) abstract_typ ->
+                 ('ctx, 'src option) typ ->
+                 'src -> ('ctx, 'a) abstract_value
+
   (** {3 Built-in scalars} *)
 
   val int    : ('ctx, int option) typ

--- a/graphql/src/graphql_schema.ml
+++ b/graphql/src/graphql_schema.ml
@@ -387,12 +387,15 @@ module Make(Io : IO) = struct
     i
 
   let add_type abstract_typ typ =
-    match abstract_typ with
-    | Abstract a ->
+    match (abstract_typ, typ) with
+    | Abstract ({ kind = `Interface _; _ } as a), Object o ->
         (* TODO add subtype check here *)
         a.types <- (AnyTyp typ)::a.types;
-        fun src ->
-          AbstractValue (typ, src)
+        o.interfaces := a :: !(o.interfaces);
+        fun src -> AbstractValue (typ, src)
+    | Abstract a, _ ->
+        a.types <- (AnyTyp typ)::a.types;
+        fun src -> AbstractValue (typ, src)
     | _ ->
         invalid_arg "The first argument must be a union or interface"
 

--- a/graphql/test/abstract_test.ml
+++ b/graphql/test/abstract_test.ml
@@ -1,0 +1,150 @@
+open Graphql
+
+type cat = {
+  name : string;
+  kittens : int;
+}
+
+type dog = {
+  name : string;
+  puppies : int;
+}
+
+let meow : cat = { name = "Meow"; kittens = 1 }
+let fido : dog = { name = "Fido"; puppies = 2 }
+
+let cat = Schema.(obj "Cat"
+  ~fields:(fun _ -> [
+    field "name"
+      ~typ:(non_null string)
+      ~args:Arg.[]
+      ~resolve:(fun () (cat : cat) -> cat.name)
+    ;
+    field "kittens"
+      ~typ:(non_null int)
+      ~args:Arg.[]
+      ~resolve:(fun () (cat : cat) -> cat.kittens)
+    ;
+  ])
+)
+
+let dog = Schema.(obj "Dog"
+  ~fields:(fun _ -> [
+    field "name"
+      ~typ:(non_null string)
+      ~args:Arg.[]
+      ~resolve:(fun () (dog : dog) -> dog.name)
+    ;
+    field "puppies"
+      ~typ:(non_null int)
+      ~args:Arg.[]
+      ~resolve:(fun () (dog : dog) -> dog.puppies)
+    ;
+  ])
+)
+
+let pet : (unit, [`pet]) Schema.abstract_typ = Schema.union "Pet"
+let cat_as_pet = Schema.add_type pet cat
+let dog_as_pet = Schema.add_type pet dog
+
+let named : (unit, [`named]) Schema.abstract_typ = Schema.(interface "Named"
+  ~fields:(fun _ -> [
+    abstract_field "name"
+      ~typ:(non_null string)
+      ~args:Arg.[]
+  ])
+)
+let cat_as_named = Schema.add_type named cat
+let dog_as_named = Schema.add_type named dog
+
+let pet_type = Schema.(Arg.enum "pet_type"
+  ~values:[
+    enum_value "CAT" ~value:`Cat;
+    enum_value "DOG" ~value:`Dog;
+  ])
+
+let schema = Schema.(schema [
+    field "pet"
+      ~typ:(non_null pet)
+      ~args:Arg.[
+        arg "type" ~typ:(non_null pet_type)
+      ]
+      ~resolve:(fun () () pet_type ->
+        match pet_type with
+        | `Cat ->
+          cat_as_pet meow
+        | `Dog ->
+          dog_as_pet fido
+      )
+    ;
+    field "pets"
+      ~typ:(non_null (list (non_null pet)))
+      ~args:Arg.[]
+      ~resolve:(fun () () -> [cat_as_pet meow; dog_as_pet fido])
+    ;
+    field "named_objects"
+      ~typ:(non_null (list (non_null named)))
+      ~args:Arg.[]
+      ~resolve:(fun () () -> [cat_as_named meow; dog_as_named fido])
+  ])
+
+let test_query = Test_common.test_query schema ()
+
+let suite = [
+  ("dog as pet", `Quick, fun () ->
+    let query = "{ pet(type: \"DOG\") { ... on Dog { name puppies } } }" in
+    test_query query (`Assoc [
+			"data", `Assoc [
+				"pet", `Assoc [
+					"name", `String "Fido";
+					"puppies", `Int 2
+				]
+			]
+		])
+  );
+  ("cat as pet", `Quick, fun () ->
+    let query = "{ pet(type: \"CAT\") { ... on Cat { name kittens } } }" in
+    test_query query (`Assoc [
+			"data", `Assoc [
+				"pet", `Assoc [
+					"name", `String "Meow";
+					"kittens", `Int 1
+				]
+			]
+		])
+  );
+  ("pets", `Quick, fun () ->
+    let query = "{ pets { ... on Dog { name puppies } ... on Cat { name kittens } } }" in
+    test_query query (`Assoc [
+			"data", `Assoc [
+				"pets", `List [
+					`Assoc [
+						"name", `String "Meow";
+						"kittens", `Int 1
+					];
+					`Assoc [
+						"name", `String "Fido";
+						"puppies", `Int 2
+					]
+				]
+			]
+		])
+  );
+  ("named_objects", `Quick, fun () ->
+    let query = "{ named_objects { name ... on Dog { puppies } ... on Cat { kittens } } }" in
+    test_query query (`Assoc [
+			"data", `Assoc [
+				"named_objects", `List [
+					`Assoc [
+						"name", `String "Meow";
+						"kittens", `Int 1
+					];
+					`Assoc [
+						"name", `String "Fido";
+						"puppies", `Int 2
+					]
+				]
+			]
+		])
+  );
+]

--- a/graphql/test/abstract_test.ml
+++ b/graphql/test/abstract_test.ml
@@ -94,57 +94,74 @@ let suite = [
   ("dog as pet", `Quick, fun () ->
     let query = "{ pet(type: \"DOG\") { ... on Dog { name puppies } } }" in
     test_query query (`Assoc [
-			"data", `Assoc [
-				"pet", `Assoc [
-					"name", `String "Fido";
-					"puppies", `Int 2
-				]
-			]
-		])
+      "data", `Assoc [
+        "pet", `Assoc [
+          "name", `String "Fido";
+          "puppies", `Int 2
+        ]
+      ]
+    ])
   );
   ("cat as pet", `Quick, fun () ->
     let query = "{ pet(type: \"CAT\") { ... on Cat { name kittens } } }" in
     test_query query (`Assoc [
-			"data", `Assoc [
-				"pet", `Assoc [
-					"name", `String "Meow";
-					"kittens", `Int 1
-				]
-			]
-		])
+      "data", `Assoc [
+        "pet", `Assoc [
+          "name", `String "Meow";
+          "kittens", `Int 1
+        ]
+      ]
+    ])
   );
   ("pets", `Quick, fun () ->
     let query = "{ pets { ... on Dog { name puppies } ... on Cat { name kittens } } }" in
     test_query query (`Assoc [
-			"data", `Assoc [
-				"pets", `List [
-					`Assoc [
-						"name", `String "Meow";
-						"kittens", `Int 1
-					];
-					`Assoc [
-						"name", `String "Fido";
-						"puppies", `Int 2
-					]
-				]
-			]
-		])
+      "data", `Assoc [
+        "pets", `List [
+          `Assoc [
+            "name", `String "Meow";
+            "kittens", `Int 1
+          ];
+          `Assoc [
+            "name", `String "Fido";
+            "puppies", `Int 2
+          ]
+        ]
+      ]
+    ])
+  );
+  ("pets with fragment", `Quick, fun () ->
+    let query = "fragment Pet on Pet { ... on Dog { name puppies } ... on Cat { name kittens } } { pets { ... Pet } }" in
+    test_query query (`Assoc [
+      "data", `Assoc [
+        "pets", `List [
+          `Assoc [
+            "name", `String "Meow";
+            "kittens", `Int 1
+          ];
+          `Assoc [
+            "name", `String "Fido";
+            "puppies", `Int 2
+          ]
+        ]
+      ]
+    ])
   );
   ("named_objects", `Quick, fun () ->
     let query = "{ named_objects { name ... on Dog { puppies } ... on Cat { kittens } } }" in
     test_query query (`Assoc [
-			"data", `Assoc [
-				"named_objects", `List [
-					`Assoc [
-						"name", `String "Meow";
-						"kittens", `Int 1
-					];
-					`Assoc [
-						"name", `String "Fido";
-						"puppies", `Int 2
-					]
-				]
-			]
-		])
+      "data", `Assoc [
+        "named_objects", `List [
+          `Assoc [
+            "name", `String "Meow";
+            "kittens", `Int 1
+          ];
+          `Assoc [
+            "name", `String "Fido";
+            "puppies", `Int 2
+          ]
+        ]
+      ]
+    ])
   );
 ]

--- a/graphql/test/abstract_test.ml
+++ b/graphql/test/abstract_test.ml
@@ -164,4 +164,96 @@ let suite = [
       ]
     ])
   );
+  ("introspection", `Quick, fun () ->
+      let query = "{ __schema { types { name kind possibleTypes { name kind } interfaces { name kind } } } }" in
+      test_query
+        query
+        (Yojson.Basic.from_string
+           {|
+             {
+               "data": {
+                 "__schema": {
+                   "types": [
+                     {
+                       "name": "Named",
+                       "kind": "INTERFACE",
+                       "possibleTypes": [
+                         {
+                           "name": "Dog",
+                           "kind": "OBJECT"
+                         },
+                         {
+                           "name": "Cat",
+                           "kind": "OBJECT"
+                         }
+                       ],
+                       "interfaces": null
+                     },
+                     {
+                       "name": "pet_type",
+                       "kind": "ENUM",
+                       "possibleTypes": null,
+                       "interfaces": null
+                     },
+                     {
+                       "name": "Cat",
+                       "kind": "OBJECT",
+                       "possibleTypes": null,
+                        "interfaces": [
+                         {
+                           "name": "Named",
+                           "kind": "INTERFACE"
+                         }
+                       ]
+                     },
+                     {
+                       "name": "Int",
+                       "kind": "SCALAR",
+                       "possibleTypes": null,
+                       "interfaces": null
+                     },
+                     {
+                       "name": "String",
+                       "kind": "SCALAR",
+                       "possibleTypes": null,
+                       "interfaces": null
+                     },
+                     {
+                       "name": "Dog",
+                       "kind": "OBJECT",
+                       "possibleTypes": null,
+                       "interfaces": [
+                         {
+                           "name": "Named",
+                           "kind": "INTERFACE"
+                         }
+                       ]
+                     },
+                     {
+                       "name": "Pet",
+                       "kind": "UNION",
+                       "possibleTypes": [
+                         {
+                           "name": "Dog",
+                           "kind": "OBJECT"
+                         },
+                         {
+                           "name": "Cat",
+                           "kind": "OBJECT"
+                         }
+                       ],
+                       "interfaces": null
+                     },
+                     {
+                       "name": "query",
+                       "kind": "OBJECT",
+                       "possibleTypes": null,
+                       "interfaces": []
+                     }
+                   ]
+                 }
+               }
+             }
+           |})
+  );
 ]

--- a/graphql/test/jbuild
+++ b/graphql/test/jbuild
@@ -11,7 +11,8 @@
     variable_test
     argument_test
     introspection_test
-    error_test))
+    error_test
+    abstract_test))
   (libraries (graphql alcotest))))
 
 (executables

--- a/graphql/test/test.ml
+++ b/graphql/test/test.ml
@@ -5,4 +5,5 @@ let () =
     "variables", Variable_test.suite;
     "introspection", Introspection_test.suite;
     "errors", Error_test.suite;
+    "abstract", Abstract_test.suite;
   ]


### PR DESCRIPTION
With this change, GraphiQL can list implementations of interfaces:

![image](https://user-images.githubusercontent.com/111265/42325483-b46e43d2-8066-11e8-929e-2ffbe1871742.png)
