### PR TITLE
Graphql_lwt: Return errors as JSON objects with 200 status code

### DIFF
--- a/graphql-lwt/src/graphql_lwt.ml
+++ b/graphql-lwt/src/graphql_lwt.ml
@@ -29,12 +29,9 @@ module Server = struct
     Lwt_io.printf "Query: %s\n" query;
     let result = execute_query ctx schema (variables :> (string * Graphql_parser.const_value) list) query in
     result >>= function
-    | Ok data ->
+    | Ok data | Error data ->
         let body = Yojson.Basic.to_string data in
         C.Server.respond_string ~status:`OK ~body ()
-    | Error err ->
-        let body = Yojson.Basic.to_string err in
-        C.Server.respond_error ~body ()
 
   let mk_callback mk_context schema conn (req : Cohttp.Request.t) body =
     Lwt_io.printf "Req: %s\n" req.resource;


### PR DESCRIPTION
With this commit:

- Errors get reported with 200 status code 
GraphQL spec has no mention of error codes since it doesn't care about the transport and uses the `error` field in the response as the source of truth for errors. If I'm understanding the common practice correctly, clients only expect HTTP error codes when the GraphQL server cannot answer the query at all.

  On top of this, GraphQL servers are also expected to return both `data` and `error` fields when it can resolve some of the queries but not the others, making the current 500 code too broad.

  Some references:
    https://github.com/graphql-python/graphene/issues/142
    https://platform.github.community/t/http-status-codes-for-requests/1860

- Errors are returned as a JSON object
  Cohttp's respond_error utility adds the "Error:" prefix to the response, making it harder for the client to parse the result.

### Before (status 500)
![screenshot from 2018-07-05 16-56-42](https://user-images.githubusercontent.com/111265/42331659-4890a3fc-8076-11e8-88b9-a7e5da77e9a2.png)

### After (status 200)
![screenshot from 2018-07-05 16-56-00](https://user-images.githubusercontent.com/111265/42331668-4dacd838-8076-11e8-9ff4-c1080f031aaf.png)

## Next steps
I'd love to have more detailed error responses. For example in Github (image below):
- In the query response, fields that have failed get set to `null`, instead of the catch-all `data: null`
- Errors have things like error type and more information regarding which query they came from.

Apollo's node server has also added something similar recently: https://www.apollographql.com/docs/apollo-server/v2/features/errors.html

![screenshot from 2018-07-05 16-57-43](https://user-images.githubusercontent.com/111265/42331765-882f6bc4-8076-11e8-9a76-13f98fde8386.png)

I'll keep investigating this as far as my ocaml-fu allows.
