### PR TITLE
Fix parsing enums that start with e

### DIFF
--- a/graphql_parser/src/graphql_parser.ml
+++ b/graphql_parser/src/graphql_parser.ml
@@ -158,7 +158,21 @@ let name = take_while1 is_name_char
 
 let is_number_char =
   function | '0' .. '9' | 'e' | 'E' | '.' | '-' | '+' -> true | _ -> false
-let number_chars = take_while1 is_number_char
+let is_leading_number_char = function | '0'..'9'|'-'|'+' -> true | _ -> false
+let leading_number_char =
+  peek_char >>=
+    (function
+     | None  -> fail "none"
+     | (Some (c)) ->
+         (match is_leading_number_char c with
+          | true  -> return()
+          | false  -> fail "no leading number char"))
+let number_chars =
+  leading_number_char >>=
+    (fun () ->
+       (take_while1 is_number_char))
+
+let number_chars (take_while1 is_number_char);
 
 let string_buf = Buffer.create 8
 


### PR DESCRIPTION
The parser thinks that enums starting with "E" are numbers because it sees the E as the exponent in a float (e.g. 1e6). 

This PR fixes that problem, but doesn't look like the ideal solution. I'm not too familiar with Angstrom, but it seems like it should be possible to implement something whose logic looks very similar to the spec: http://facebook.github.io/graphql/draft/#sec-Int-Value

Have you considered using libgraphqlparser instead of a custom parser? That could give users of the ocaml-graphql-server a much better experience with parser errors.