### PR TITLE
Allow introspection of default args for built-in scalars

### DIFF
--- a/graphql/src/graphql_intf.ml
+++ b/graphql/src/graphql_intf.ml
@@ -56,6 +56,7 @@ module type Schema = sig
 
     val scalar : ?doc:string ->
                  string ->
+                 default_doc:('a -> Yojson.Basic.json) ->
                  coerce:(Graphql_parser.const_value -> ('a, string) result) ->
                  'a option arg_typ
 


### PR DESCRIPTION
I made a quick attempt to add default values for arguments to the introspection query. Only covers built-in scalars for now. 

I couldn't figure out if this information is already available in the introspection resolvers, so I added a new parameter to Arg.scalar. This will break backwards compatibility for people using custom scalar arguments, to avoid this I can make this argument optional. Please let me know if this is in the right direction.

Here's what it looks like in GraphiQL:

![screenshot from 2018-07-24 22-33-37](https://user-images.githubusercontent.com/111265/43164508-a80addd2-8f91-11e8-9df8-007dac5f75e3.png)
