### PR TITLE
Subscription support

### DIFF
--- a/graphql-async/src/graphql_async.ml
+++ b/graphql-async/src/graphql_async.ml
@@ -1,5 +1,15 @@
-module Schema = Graphql_schema.Make(struct
+module Io = struct
   include Async_kernel.Deferred
 
   let bind x f = bind x ~f
-end)
+end
+
+module Stream = struct
+  type +'a io = 'a Async_kernel.Deferred.t
+  type 'a t = 'a Async_kernel.Pipe.Reader.t
+
+  let map x f = Async_kernel.Pipe.map' x ~f:(fun q ->
+    Async_kernel.Deferred.Queue.map q ~f)
+end
+
+module Schema = Graphql_schema.Make (Io) (Stream)

--- a/graphql-async/src/graphql_async.mli
+++ b/graphql-async/src/graphql_async.mli
@@ -1,4 +1,5 @@
 (** GraphQL schema with Async support *)
 module Schema : sig
   include Graphql_intf.Schema with type 'a io = 'a Async_kernel.Deferred.t
+                              and type 'a stream = 'a Async_kernel.Pipe.Reader.t
 end

--- a/graphql-async/test/async_test.ml
+++ b/graphql-async/test/async_test.ml
@@ -16,12 +16,14 @@ let test_query schema ctx query expected =
     match Graphql_parser.parse query with
     | Error err -> failwith err
     | Ok doc ->
-      Graphql_async.Schema.execute schema ctx doc >>| fun result ->
-      let result' = match result with
-      | Ok data -> data
-      | Error err -> err
-      in
-      Alcotest.check yojson "invalid execution result" expected result'
+      Graphql_async.Schema.execute schema ctx doc >>= (function
+      | Ok (`Response data) -> Async_kernel.return data
+      | Ok (`Stream stream) ->
+          Async_kernel.Pipe.to_list stream >>| fun lst ->
+            `List Core_kernel.(List.map lst ~f:(fun x -> Option.value_exn (Result.ok x)))
+      | Error err -> Async_kernel.return err)
+      >>| fun result ->
+        Alcotest.check yojson "invalid execution result" expected result
   end
 
 let schema = Graphql_async.Schema.(schema [
@@ -35,6 +37,13 @@ let schema = Graphql_async.Schema.(schema [
         ~args:Arg.[]
         ~resolve:(fun () () -> Deferred.return (Ok 42))
     ]
+  ~subscriptions:[
+    subscription_field "int_stream"
+      ~typ:(non_null int)
+      ~args:Arg.[]
+      ~resolve:(fun () ->
+        Async_kernel.Deferred.Result.return (Async_kernel.Pipe.of_list [1; 2; 3]))
+  ]
 )
 
 let suite = [
@@ -46,6 +55,25 @@ let suite = [
       ]
     ])
   );
+  ("subscription", `Quick, fun () ->
+    test_query schema () "subscription { int_stream }" (`List [
+      `Assoc [
+        "data", `Assoc [
+          "int_stream", `Int 1
+        ]
+      ];
+      `Assoc [
+        "data", `Assoc [
+          "int_stream", `Int 2
+        ]
+      ];
+      `Assoc [
+        "data", `Assoc [
+          "int_stream", `Int 3
+        ]
+      ]
+    ])
+  )
 ]
 
 let () = Alcotest.run "graphql-server" ["async", suite]

--- a/graphql-lwt/src/graphql_lwt.mli
+++ b/graphql-lwt/src/graphql_lwt.mli
@@ -1,6 +1,7 @@
 (** GraphQL schema with Lwt support *)
 module Schema : sig
   include Graphql_intf.Schema with type 'a io = 'a Lwt.t
+                              and type 'a stream = 'a Lwt_stream.t * (unit -> unit)
 end
 
 module Server : sig

--- a/graphql.opam
+++ b/graphql.opam
@@ -12,6 +12,7 @@ depends: [
   "graphql_parser"
   "yojson"
   "rresult"
+  "seq"
   "alcotest" {test}
 ]
 available: [

--- a/graphql/src/graphql.ml
+++ b/graphql/src/graphql.ml
@@ -1,6 +1,15 @@
-module Schema = Graphql_schema.Make(struct
+module Io = struct
   type +'a t = 'a
 
   let bind x f = f x
   let return x = x
-end)
+end
+
+module Stream = struct
+  type +'a io = 'a Io.t
+  type 'a t = 'a Seq.t
+
+  let map x f = Seq.map f x
+end
+
+module Schema = Graphql_schema.Make (Io) (Stream)

--- a/graphql/src/graphql.mli
+++ b/graphql/src/graphql.mli
@@ -1,4 +1,5 @@
 (** GraphQL schema *)
 module Schema : sig
   include Graphql_intf.Schema with type +'a io = 'a
+                              and type 'a stream = 'a Seq.t
 end

--- a/graphql/src/graphql_schema.ml
+++ b/graphql/src/graphql_schema.ml
@@ -33,9 +33,18 @@ module type IO = sig
   val bind : 'a t -> ('a -> 'b t) -> 'b t
 end
 
+(* Stream *)
+module type Stream = sig
+  type +'a io
+  type 'a t
+
+  val map : 'a t -> ('a -> 'b io) -> 'b t
+end
+
 (* Schema *)
-module Make(Io : IO) = struct
+module Make (Io : IO) (Stream: Stream with type 'a io = 'a Io.t) = struct
   type +'a io = 'a Io.t
+  type 'a stream = 'a Stream.t
 
   module Io = struct
     include Io
@@ -231,7 +240,7 @@ module Make(Io : IO) = struct
               eval_arglist variable_map arglist' key_values (f coerced)
             with StringMap.Missing_key key -> Error (Format.sprintf "Missing variable `%s`" key)
 
-    and eval_arg : type a. variable_map ->  a arg_typ -> Graphql_parser.const_value option -> (a, string) result = fun variable_map typ value ->
+    and eval_arg : type a. variable_map -> a arg_typ -> Graphql_parser.const_value option -> (a, string) result = fun variable_map typ value ->
       match (typ, value) with
       | NonNullable _, None -> Error "Missing required argument"
       | NonNullable _, Some `Null -> Error "Missing required argument"
@@ -329,14 +338,36 @@ module Make(Io : IO) = struct
   and ('ctx, 'a) abstract_value =
     AbstractValue : ('ctx, 'src option) typ * 'src -> ('ctx, 'a) abstract_value
 
+  type 'ctx subscription_field =
+    SubscriptionField : {
+      name       : string;
+      doc        : string option;
+      deprecated : deprecated;
+      typ        : ('ctx, 'out) typ;
+      args       : (('out stream, string) result io, 'args) Arg.arg_list;
+      resolve    : 'ctx -> 'args;
+    } -> 'ctx subscription_field
+
+  type 'ctx subscription_obj = {
+    name   : string;
+    doc    : string option;
+    fields : 'ctx subscription_field list;
+  }
+
   type ('ctx, 'a) abstract_typ = ('ctx, ('ctx, 'a) abstract_value option) typ
 
   type 'ctx schema = {
     query : ('ctx, unit) obj;
     mutation : ('ctx, unit) obj option;
+    subscription : 'ctx subscription_obj option;
   }
 
-  let schema ?(mutation_name="mutation") ?mutations ?(query_name="query") fields = {
+  let schema ?(mutation_name="mutation")
+             ?mutations
+             ?(subscription_name="subscription")
+             ?subscriptions
+             ?(query_name="query")
+             fields = {
     query = {
       name = query_name;
       doc = None;
@@ -349,6 +380,13 @@ module Make(Io : IO) = struct
         doc = None;
         abstracts = ref [];
         fields = lazy fields;
+      }
+    );
+    subscription = Option.map subscriptions ~f:(fun fields ->
+      {
+        name = subscription_name;
+        doc = None;
+        fields;
       }
     )
   }
@@ -366,6 +404,9 @@ module Make(Io : IO) = struct
 
   let abstract_field ?doc ?(deprecated=NotDeprecated) name ~typ ~args =
     AbstractField (Field { lift = Io.ok; name; doc; deprecated; typ; args; resolve = Obj.magic () })
+
+  let subscription_field ?doc ?(deprecated=NotDeprecated) name ~typ ~args ~resolve =
+    SubscriptionField { name; doc; deprecated; typ; args; resolve }
 
   let enum ?doc name ~values =
     Enum { name; doc; values }
@@ -395,6 +436,14 @@ module Make(Io : IO) = struct
         fun src -> AbstractValue (typ, src)
     | _ ->
         invalid_arg "Arguments must be Interface/Union and Object"
+
+  let obj_of_subscription_obj {name; doc; fields} =
+    let fields = List.map
+      (fun (SubscriptionField {name; doc; deprecated; typ; args; resolve}) ->
+        Field { lift = Obj.magic (); name; doc; deprecated; typ; args; resolve = (fun ctx () -> resolve ctx) })
+      fields
+    in
+    { name; doc; abstracts = ref []; fields = lazy fields }
 
   (* Built-in scalars *)
   let int : 'ctx. ('ctx, int option) typ = Scalar {
@@ -911,10 +960,15 @@ module Introspection = struct
         args = Arg.[];
         lift = Io.ok;
         resolve = fun _ s ->
-          let query_types, visited = types (Object s.query) in
-          match s.mutation with
-          | None -> query_types
-          | Some mut -> fst @@ types ~memo:(query_types, visited) (Object mut)
+          let types, _ = List.fold_left
+            (fun memo op ->
+              match op with
+              | None -> memo
+              | Some op -> types ~memo (Object op))
+            ([], StringSet.empty)
+            [Some s.query; s.mutation; Option.map s.subscription obj_of_subscription_obj]
+          in
+          types
       };
       Field {
         name = "queryType";
@@ -933,6 +987,16 @@ module Introspection = struct
         args = Arg.[];
         lift = Io.ok;
         resolve = fun _ s -> Option.map s.mutation ~f:(fun mut -> AnyTyp (Object mut))
+      };
+      Field {
+        name = "subscriptionType";
+        doc = None;
+        deprecated = NotDeprecated;
+        typ = __type;
+        args = Arg.[];
+        lift = Io.ok;
+        resolve = fun _ s ->
+          Option.map s.subscription ~f:(fun subs -> AnyTyp (Object (obj_of_subscription_obj subs)))
       };
       Field {
         name = "directives";
@@ -980,11 +1044,11 @@ end
     ctx       : 'ctx;
   }
 
-  let matches_type_condition type_condition obj =
+  let matches_type_condition type_condition (obj : ('ctx, 'src) obj) =
     obj.name = type_condition ||
       List.exists (fun (abstract : abstract) -> abstract.name = type_condition) !(obj.abstracts)
 
-  let rec collect_fields : fragment_map -> ('ctx, 'src) obj -> Graphql_parser.selection list -> Graphql_parser.field list = fun fragment_map obj fields -> 
+  let rec collect_fields : fragment_map -> ('ctx, 'src) obj -> Graphql_parser.selection list -> Graphql_parser.field list = fun fragment_map obj fields ->
     List.map (function
     | Graphql_parser.Field field ->
         [field]
@@ -1013,6 +1077,9 @@ end
   let field_from_object : ('ctx, 'src) obj -> string -> ('ctx, 'src) field option = fun obj field_name ->
     List.find (fun (Field field) -> field.name = field_name) (Lazy.force obj.fields)
 
+  let field_from_subscription_object = fun obj field_name ->
+    List.find (fun (SubscriptionField field) -> field.name = field_name) obj.fields
+
   let coerce_or_null : 'a option -> ('a -> (Yojson.Basic.json * string list, 'b) result Io.t) -> (Yojson.Basic.json * string list, 'b) result Io.t =
     fun src f ->
       match src with
@@ -1022,6 +1089,9 @@ end
   let map_fields_with_order = function
     | Serial -> Io.map_s ~memo:[]
     | Parallel -> Io.map_p
+
+  let error_to_json err =
+    `Assoc ["message", `String err]
 
   let rec present : type ctx src. ctx execution_context -> src -> Graphql_parser.field -> (ctx, src) typ -> (Yojson.Basic.json * string list, [`Validation_error of string | `Argument_error of string | `Resolve_error of string]) result Io.t =
     fun ctx src query_field typ ->
@@ -1100,28 +1170,96 @@ end
     | `Resolve_error of string
     | `Validation_error of string
     | `Mutations_not_configured
-    | `Subscriptions_not_implemented
+    | `Subscriptions_not_configured
     | `No_operation_found
     | `Operation_name_required
     | `Operation_not_found
   ]
 
-  let execute_operation : 'ctx schema -> 'ctx execution_context -> fragment_map -> variable_map -> Graphql_parser.operation -> (Yojson.Basic.json * string list, [> execute_error]) result Io.t =
+  type 'a response = ('a, Yojson.Basic.json) result
+
+  let data_to_json = function
+    | data, [] -> `Assoc ["data", data]
+    | data, errors ->
+        let errors = List.map error_to_json errors in
+        `Assoc [
+          "data", data;
+          "errors", `List errors]
+
+  let error_response err =
+    `Assoc [
+      "errors", `List [
+        error_to_json err
+      ]
+    ]
+
+  let to_response = function
+    | Ok response as res -> res
+    | Error `No_operation_found ->
+        Error (error_response "No operation found")
+    | Error `Operation_not_found ->
+        Error (error_response "Operation not found")
+    | Error `Operation_name_required ->
+        Error (error_response "Operation name required")
+    | Error `Subscriptions_not_configured ->
+        Error (error_response "Subscriptions not configured")
+    | Error `Mutations_not_configured ->
+        Error (error_response "Mutations not configured")
+    | Error `Validation_error err ->
+        Error (error_response err)
+    | Error (`Argument_error err)
+    | Error (`Resolve_error err) ->
+        let `Assoc errors = error_response err in
+        Error (`Assoc (("data", `Null)::errors))
+
+  let subscribe : type ctx. ctx execution_context -> ctx subscription_field -> Graphql_parser.field -> ((Yojson.Basic.json, Yojson.Basic.json) result Stream.t, [`Validation_error of string | `Argument_error of string | `Resolve_error of string]) result Io.t
+  =
+    fun ctx (SubscriptionField subs_field) field ->
+      let open Io.Infix in
+      let resolver = subs_field.resolve ctx.ctx in
+      match Arg.eval_arglist ctx.variables subs_field.args field.arguments resolver with
+      | Ok result ->
+          result
+          |> Io.Result.map ~f:(fun source_stream ->
+              Stream.map source_stream (fun value ->
+                present ctx value field subs_field.typ
+                |> Io.Result.map ~f:(fun (data, errors) ->
+                  (data_to_json (`Assoc [(alias_or_name field), data], errors)))
+                >>| to_response))
+          |> Io.Result.map_error ~f:(fun err -> `Resolve_error err)
+      | Error err -> Io.error (`Argument_error err)
+
+  let execute_operation : 'ctx schema -> 'ctx execution_context -> fragment_map -> variable_map -> Graphql_parser.operation -> ([ `Response of Yojson.Basic.json | `Stream of Yojson.Basic.json response stream], [> execute_error]) result Io.t =
     fun schema ctx fragments variables operation ->
       match operation.optype with
       | Graphql_parser.Query ->
           let query  = schema.query in
           let fields = collect_fields fragments query operation.selection_set in
           (resolve_fields ctx () query fields : (Yojson.Basic.json * string list, [`Validation_error of string | `Argument_error of string | `Resolve_error of string]) result Io.t :> (Yojson.Basic.json * string list, [> execute_error]) result Io.t)
+          |> Io.Result.map ~f:(fun data_errs -> `Response (data_to_json data_errs))
       | Graphql_parser.Mutation ->
           begin match schema.mutation with
           | None -> Io.error `Mutations_not_configured
           | Some mut ->
               let fields = collect_fields fragments mut operation.selection_set in
               (resolve_fields ~execution_order:Serial ctx () mut fields : (Yojson.Basic.json * string list, [`Validation_error of string | `Argument_error of string | `Resolve_error of string]) result Io.t :> (Yojson.Basic.json * string list, [> execute_error]) result Io.t)
+              |> Io.Result.map ~f:(fun data_errs -> `Response (data_to_json data_errs))
           end
       | Graphql_parser.Subscription ->
-          Io.error `Subscriptions_not_implemented
+          begin match schema.subscription with
+          | None -> Io.error `Subscriptions_not_configured
+          | Some subs ->
+              begin match collect_fields fragments (obj_of_subscription_obj subs) operation.selection_set with
+              | [field] ->
+                  (match field_from_subscription_object subs field.name with
+                   | Some subscription_field ->
+                       (subscribe ctx subscription_field field : ((Yojson.Basic.json, Yojson.Basic.json) result Stream.t, [`Validation_error of string | `Argument_error of string | `Resolve_error of string]) result Io.t :> ((Yojson.Basic.json, Yojson.Basic.json) result Stream.t, [> execute_error]) result Io.t)
+                       |> Io.Result.map ~f:(fun stream -> `Stream stream)
+                   | None -> Io.ok (`Response (`Assoc [(alias_or_name field, `Null)])))
+              (* see http://facebook.github.io/graphql/June2018/#sec-Response-root-field *)
+              | _ -> Io.error (`Validation_error "Subscriptions only allow exactly one selection for the operation.")
+              end
+          end
 
   let collect_fragments doc =
     List.fold_left (fun memo -> function
@@ -1181,16 +1319,6 @@ end
         with Not_found ->
           Error `Operation_not_found
 
-  let error_to_json err =
-    `Assoc ["message", `String err]
-
-  let error_response err =
-    `Assoc [
-      "errors", `List [
-        error_to_json err
-      ]
-    ]
-
   let execute schema ctx ?variables:(variables=[]) ?operation_name doc =
     let open Io.Infix in
     let execute' schema ctx doc =
@@ -1201,29 +1329,5 @@ end
       Io.return (select_operation ?operation_name doc) >>=? fun op ->
       execute_operation schema' execution_ctx fragments variables op
     in
-    execute' schema ctx doc >>| function
-    | Ok (data, []) ->
-        Ok (`Assoc ["data", data])
-    | Ok (data, errors) ->
-        let errors = List.map error_to_json errors in
-        Ok (`Assoc [
-          "data", data;
-          "errors", `List errors
-        ])
-    | Error `No_operation_found ->
-        Error (error_response "No operation found")
-    | Error `Operation_not_found ->
-        Error (error_response "Operation not found")
-    | Error `Operation_name_required ->
-        Error (error_response "Operation name required")
-    | Error `Subscriptions_not_implemented ->
-        Error (error_response "Subscriptions not implemented")
-    | Error `Mutations_not_configured ->
-        Error (error_response "Mutations not configured")
-    | Error `Validation_error err ->
-        Error (error_response err)
-    | Error (`Argument_error err)
-    | Error (`Resolve_error err) ->
-        let `Assoc errors = error_response err in
-        Error (`Assoc (("data", `Null)::errors))
+    execute' schema ctx doc >>| to_response
 end

--- a/graphql/src/graphql_schema.mli
+++ b/graphql/src/graphql_schema.mli
@@ -8,5 +8,15 @@ module type IO = sig
   val bind : 'a t -> ('a -> 'b t) -> 'b t
 end
 
+(* Stream *)
+module type Stream = sig
+  type +'a io
+  type 'a t
+
+  val map : 'a t -> ('a -> 'b io) -> 'b t
+end
+
 (* GraphQL schema functor *)
-module Make(Io : IO) : Graphql_intf.Schema with type 'a io = 'a Io.t
+module Make (Io : IO) (Stream : Stream with type 'a io = 'a Io.t) :
+  Graphql_intf.Schema with type 'a io = 'a Io.t
+                      and type 'a stream = 'a Stream.t

--- a/graphql/src/jbuild
+++ b/graphql/src/jbuild
@@ -4,4 +4,4 @@
  ((name graphql)
   (public_name graphql)
   (wrapped false)
-  (libraries (graphql_parser yojson rresult))))
+  (libraries (graphql_parser yojson rresult seq))))

--- a/graphql/test/schema_test.ml
+++ b/graphql/test/schema_test.ml
@@ -254,4 +254,53 @@ let suite = [
         | Error err -> failwith (Yojson.Basic.pretty_to_string err)
         end
   );
+  ("subscription", `Quick, fun () ->
+    let query = "subscription { subscribe_to_user { id name } }" in
+    test_query query (`List [
+      `Assoc [
+        "data", `Assoc [
+          "subscribe_to_user", `Assoc [
+            "id", `Int 1;
+            "name", `String "Alice"
+          ];
+        ]
+      ]
+    ])
+  );
+  ("subscription returns an error", `Quick, fun () ->
+    let query = "subscription { subscribe_to_user(error: true) { id name } }" in
+    test_query query (`Assoc [
+      "data", `Null;
+      "errors", `List [
+        `Assoc [
+          "message", `String "stream error";
+        ]
+      ]
+    ])
+  );
+  ("subscriptions: exn inside the stream", `Quick, fun () ->
+    let query = "subscription { subscribe_to_user(raise: true) { id name } }" in
+    test_query query (`String "caught stream exn")
+  );
+  ("subscription returns more than one value", `Quick, fun () ->
+    let query = "subscription { subscribe_to_user(first: 2) { id name } }" in
+    test_query query (`List [
+      `Assoc [
+        "data", `Assoc [
+          "subscribe_to_user", `Assoc [
+            "id", `Int 1;
+            "name", `String "Alice"
+          ];
+        ]
+      ];
+      `Assoc [
+        "data", `Assoc [
+          "subscribe_to_user", `Assoc [
+            "id", `Int 2;
+            "name", `String "Bob"
+          ];
+        ]
+      ]
+    ])
+  )
 ]

--- a/graphql/test/test_common.ml
+++ b/graphql/test/test_common.ml
@@ -7,12 +7,27 @@ let yojson = (module struct
   let equal = (=)
 end : Alcotest.TESTABLE with type t = Yojson.Basic.json)
 
+let list_of_seq seq =
+  let rec loop seq =
+    match seq() with
+      | Seq.Nil -> []
+      | Seq.Cons (Ok x, next) -> x :: loop next
+      | Seq.Cons (Error _, _) -> assert false
+  in
+  loop seq
+
 let test_query schema ctx ?variables ?operation_name query expected =
   match Graphql_parser.parse query with
   | Error err -> failwith err
   | Ok doc ->
       let result = match Graphql.Schema.execute schema ctx ?variables ?operation_name doc with
-      | Ok data -> data
+      | Ok (`Response data) -> data
+      | Ok (`Stream stream) ->
+          begin try match stream () with
+          | Seq.Cons (Ok data, _) -> `List (list_of_seq stream)
+          | Seq.Cons (Error err, _) -> err
+          | Seq.Nil -> `Null
+          with _ -> `String "caught stream exn" end
       | Error err -> err
       in
       Alcotest.check yojson "invalid execution result" expected result


### PR DESCRIPTION
This is a WIP PR for adding subscription support to OCaml-GraphQL-Server.

### Things that are effectively implemented:

- [x] introspection for subscriptions
- [x] simple validation (according to the spec) that asserts a subscription only has one field 
- [x] calling the `subscribe` function

### Things that are still WIP (& for which feedback is greatly appreciated!)

- [x] settle on the type definitions. 
  - Right now a `SubscriptionField` has a `subscribe : 'ctx -> 'src -> 'args` and a `resolve : 'ctx -> 'out -> 'out` function. According to the spec, `resolve` is meant to be a mapper from `'out -> 'out`, and we want to return an `Io_stream.t` from `subscribe`. If we make both functions support `'args` I don't see a way to make them return different types. Maybe this is fine and `resolve` doesn't need args, but it'd be nice to have?
- [x] Execute the query in response to an event
  - Right now OGS gets the "source stream" from the `subscribe` function but not doing anything with it. This is the area where I have the most questions
  - The spec mentions that the "response stream" is basically a "mapper" over the source stream that executes the selection set of the subscription in response to any events in the stream. I think we have 2 alternatives here:
    1. Create a "mapped" stream from the source stream to which OGS pushes responses. This is effectively the "response stream" that the spec talks about, but we'd need a way to hand this response stream to the user (could be the result of executing but again the types don't match with the query execution types for example)
    2. Let the user do the job of setting up the stream and provide a helper to execute the selection set that the user can use when setting up the subscription behavior (this would need more info in the resolver – basically solving https://github.com/andreas/ocaml-graphql-server/issues/42); I'm leaning more towards this approach as it also offloads any decisions as to which types / libraries to use for streaming subscriptions to consumers of OGS – it's the less opinionated
  - another open question is if we want to support filtering events on the stream, which e.g. Apollo makes possible.