### PR TITLE
Fixed dune exec script

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ git clone git@github.com:andreas/ocaml-graphql-server.git
 cd ocaml-graphql-server
 cd examples
 dune build server.exe
-dune exec ./examples/server.exe
+dune exec ./server.exe
 ```
 
 Now open [http://localhost:8080/graphql](http://localhost:8080/graphql).


### PR DESCRIPTION
We have already cd'd into the examples folder so running `dune exec ./examples/server.exe` doesn't work.