### PR TITLE
Update instructions to run the example project

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ API documentation:
 To run a sample GraphQL server also serving GraphiQL, do the following:
 
 ```bash
-opam install graphql-lwt dune async_kernel
+opam install graphql-lwt dune seq
 git clone git@github.com:andreas/ocaml-graphql-server.git
 cd ocaml-graphql-server/examples
 dune exec ./server.exe

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ API documentation:
 To run a sample GraphQL server also serving GraphiQL, do the following:
 
 ```bash
-opam install graphql-lwt dune
+opam install graphql-lwt dune async_kernel
 git clone git@github.com:andreas/ocaml-graphql-server.git
 cd ocaml-graphql-server/examples
 dune exec ./server.exe


### PR DESCRIPTION
To make it work, I had to `opam install async_kernel`.

This was on a clean `opam switch create 4.07.0` and `opam switch create 4.07.1`