### PR TITLE
Resolve params rebase

### DIFF
--- a/examples/server.ml
+++ b/examples/server.ml
@@ -29,22 +29,22 @@ let user = Schema.(obj "user"
     field "id"
       ~args:Arg.[]
       ~typ:(non_null int)
-      ~resolve:(fun () p -> p.id)
+      ~resolve:(fun _ p -> p.id)
     ;
     field "name"
       ~args:Arg.[]
       ~typ:(non_null string)
-      ~resolve:(fun () p -> p.name)
+      ~resolve:(fun _ p -> p.name)
     ;
     field "role"
       ~args:Arg.[]
       ~typ:(non_null role)
-      ~resolve:(fun () p -> p.role)
+      ~resolve:(fun _ p -> p.role)
     ;
     field "friends"
       ~args:Arg.[]
       ~typ:(list (non_null user))
-      ~resolve:(fun () p -> Some p.friends)
+      ~resolve:(fun _ p -> Some p.friends)
   ])
 )
 
@@ -78,7 +78,7 @@ let schema = Schema.(schema [
     io_field "users"
       ~args:Arg.[]
       ~typ:(non_null (list (non_null user)))
-      ~resolve:(fun () () -> Lwt_result.return users)
+      ~resolve:(fun _ () -> Lwt_result.return users)
     ;
     field "greeter"
       ~typ:string
@@ -88,7 +88,7 @@ let schema = Schema.(schema [
           arg "name" ~typ:(non_null string)
         ]))
       ]
-      ~resolve:(fun () () (greeting, name) ->
+      ~resolve:(fun _ () (greeting, name) ->
         Some (Format.sprintf "%s, %s" greeting name)
       )
     ;
@@ -97,7 +97,7 @@ let schema = Schema.(schema [
       subscription_field "subscribe_to_user"
         ~typ:(non_null user)
         ~args:Arg.[arg' "intarg" ~typ:int ~default:42]
-        ~resolve:(fun _ctx _intarg ->
+        ~resolve:(fun _params _intarg ->
           let user_stream, push_to_user_stream = Lwt_stream.create () in
           let destroy_stream = (fun () -> push_to_user_stream None) in
           set_interval 2 (fun () ->

--- a/graphql-async/test/async_test.ml
+++ b/graphql-async/test/async_test.ml
@@ -29,18 +29,18 @@ let schema = Graphql_async.Schema.(schema [
       field "direct_string"
         ~typ:(non_null string)
         ~args:Arg.[]
-        ~resolve:(fun () () -> "foo")
+        ~resolve:(fun _ () -> "foo")
       ;
       io_field "io_int"
         ~typ:(non_null int)
         ~args:Arg.[]
-        ~resolve:(fun () () -> Deferred.return (Ok 42))
+        ~resolve:(fun _ () -> Deferred.return (Ok 42))
     ]
   ~subscriptions:[
     subscription_field "int_stream"
       ~typ:(non_null int)
       ~args:Arg.[]
-      ~resolve:(fun () ->
+      ~resolve:(fun _ ->
         Async_kernel.Deferred.Result.return (Async_kernel.Pipe.of_list [1; 2; 3]))
   ]
 )

--- a/graphql-lwt/test/lwt_test.ml
+++ b/graphql-lwt/test/lwt_test.ml
@@ -31,18 +31,18 @@ let schema = Graphql_lwt.Schema.(schema [
       field "direct_string"
         ~typ:(non_null string)
         ~args:Arg.[]
-        ~resolve:(fun () () -> "foo")
+        ~resolve:(fun _ () -> "foo")
       ;
       io_field "io_int"
         ~typ:(non_null int)
         ~args:Arg.[]
-        ~resolve:(fun () () -> Lwt.return (Ok 42))
+        ~resolve:(fun _ () -> Lwt.return (Ok 42))
     ]
   ~subscriptions:[
     subscription_field "int_stream"
       ~typ:(non_null int)
       ~args:Arg.[]
-      ~resolve:(fun () ->
+      ~resolve:(fun _ ->
         let stream = Lwt_stream.of_list [1; 2; 3] in
         let destroy = (fun () -> ()) in
         Lwt_result.return (stream, destroy))

--- a/graphql/src/graphql_intf.ml
+++ b/graphql/src/graphql_intf.ml
@@ -3,6 +3,14 @@ module type Schema = sig
   type +'a io
   type 'a stream
 
+  module StringMap : sig
+    include Map.S with type key = string
+    (* Map.S with type key = String.t *)
+    exception Missing_key of key
+    val find_exn : key -> 'a t -> 'a
+    val find : key -> 'a t -> 'a option
+  end
+
   (** {3 Base types } *)
 
   type 'ctx schema
@@ -85,9 +93,13 @@ module type Schema = sig
     val non_null : 'a option arg_typ -> 'a arg_typ
   end
 
+  type variable_map = Graphql_parser.const_value StringMap.t
+  type fragment_map = Graphql_parser.fragment StringMap.t
   type 'ctx resolve_params = {
     ctx : 'ctx;
     field : Graphql_parser.field;
+    fragments : fragment_map;
+    variables : variable_map;
   }
 
   val field : ?doc:string ->

--- a/graphql/src/graphql_intf.ml
+++ b/graphql/src/graphql_intf.ml
@@ -85,12 +85,17 @@ module type Schema = sig
     val non_null : 'a option arg_typ -> 'a arg_typ
   end
 
+  type 'ctx resolve_params = {
+    ctx : 'ctx;
+    field : Graphql_parser.field;
+  }
+
   val field : ?doc:string ->
               ?deprecated:deprecated ->
               string ->
               typ:('ctx, 'a) typ ->
               args:('a, 'b) Arg.arg_list ->
-              resolve:('ctx -> 'src -> 'b) ->
+              resolve:('ctx resolve_params -> 'src -> 'b) ->
               ('ctx, 'src) field
 
   val io_field : ?doc:string ->
@@ -98,7 +103,7 @@ module type Schema = sig
                  string ->
                  typ:('ctx, 'a) typ ->
                  args:(('a, string) result io, 'b) Arg.arg_list ->
-                 resolve:('ctx -> 'src -> 'b) ->
+                 resolve:('ctx resolve_params -> 'src -> 'b) ->
                  ('ctx, 'src) field
 
   val subscription_field : ?doc:string ->

--- a/graphql/src/graphql_intf.ml
+++ b/graphql/src/graphql_intf.ml
@@ -111,7 +111,7 @@ module type Schema = sig
                            string ->
                            typ:('ctx, 'out) typ ->
                            args:(('out stream, string) result io, 'args) Arg.arg_list ->
-                           resolve:('ctx -> 'args) ->
+                           resolve:('ctx resolve_params -> 'args) ->
                            'ctx subscription_field
 
   val enum : ?doc:string ->

--- a/graphql/src/graphql_schema.ml
+++ b/graphql/src/graphql_schema.ml
@@ -294,9 +294,12 @@ module Make (Io : IO) (Stream: Stream with type 'a io = 'a Io.t) = struct
     values  : 'a enum_value list;
   }
 
+  type fragment_map = Graphql_parser.fragment StringMap.t
   type 'ctx resolve_params = {
     ctx : 'ctx;
     field : Graphql_parser.field;
+    fragments : fragment_map;
+    variables : variable_map;
   }
 
   type ('ctx, 'src) obj = {
@@ -1036,7 +1039,6 @@ end
 
   (* Execution *)
   type variables = (string * Graphql_parser.const_value) list
-  type fragment_map = Graphql_parser.fragment StringMap.t
   type execution_order = Serial | Parallel
   type 'ctx execution_context = {
     variables : variable_map;
@@ -1160,6 +1162,8 @@ end
       let resolve_params = {
         ctx = ctx.ctx;
         field = query_field;
+        fragments = ctx.fragments;
+        variables = ctx.variables;
       } in
       let resolver = field.resolve resolve_params src in
       match Arg.eval_arglist ctx.variables field.args query_field.arguments resolver with
@@ -1241,6 +1245,8 @@ end
       let resolve_params = {
         ctx = ctx.ctx;
         field;
+        fragments = ctx.fragments;
+        variables = ctx.variables
       } in
       let resolver = subs_field.resolve resolve_params in
       match Arg.eval_arglist ctx.variables subs_field.args field.arguments resolver with

--- a/graphql/src/graphql_schema.ml
+++ b/graphql/src/graphql_schema.ml
@@ -343,7 +343,7 @@ module Make (Io : IO) (Stream: Stream with type 'a io = 'a Io.t) = struct
       deprecated : deprecated;
       typ        : ('ctx, 'out) typ;
       args       : (('out stream, string) result io, 'args) Arg.arg_list;
-      resolve    : 'ctx -> 'args;
+      resolve    : 'ctx resolve_params -> 'args;
     } -> 'ctx subscription_field
 
   type 'ctx subscription_obj = {
@@ -1238,7 +1238,11 @@ end
       let open Io.Infix in
       let name = alias_or_name field in
       let path = [`String name] in
-      let resolver = subs_field.resolve ctx.ctx in
+      let resolve_params = {
+        ctx = ctx.ctx;
+        field;
+      } in
+      let resolver = subs_field.resolve resolve_params in
       match Arg.eval_arglist ctx.variables subs_field.args field.arguments resolver with
       | Ok result ->
           result

--- a/graphql/test/abstract_test.ml
+++ b/graphql/test/abstract_test.ml
@@ -18,12 +18,12 @@ let cat = Schema.(obj "Cat"
     field "name"
       ~typ:(non_null string)
       ~args:Arg.[]
-      ~resolve:(fun () (cat : cat) -> cat.name)
+      ~resolve:(fun _ (cat : cat) -> cat.name)
     ;
     field "kittens"
       ~typ:(non_null int)
       ~args:Arg.[]
-      ~resolve:(fun () (cat : cat) -> cat.kittens)
+      ~resolve:(fun _ (cat : cat) -> cat.kittens)
     ;
   ])
 )
@@ -33,12 +33,12 @@ let dog = Schema.(obj "Dog"
     field "name"
       ~typ:(non_null string)
       ~args:Arg.[]
-      ~resolve:(fun () (dog : dog) -> dog.name)
+      ~resolve:(fun _ (dog : dog) -> dog.name)
     ;
     field "puppies"
       ~typ:(non_null int)
       ~args:Arg.[]
-      ~resolve:(fun () (dog : dog) -> dog.puppies)
+      ~resolve:(fun _ (dog : dog) -> dog.puppies)
     ;
   ])
 )
@@ -69,7 +69,7 @@ let schema = Schema.(schema [
       ~args:Arg.[
         arg "type" ~typ:(non_null pet_type)
       ]
-      ~resolve:(fun () () pet_type ->
+      ~resolve:(fun _ () pet_type ->
         match pet_type with
         | `Cat ->
           cat_as_pet meow
@@ -80,12 +80,12 @@ let schema = Schema.(schema [
     field "pets"
       ~typ:(non_null (list (non_null pet)))
       ~args:Arg.[]
-      ~resolve:(fun () () -> [cat_as_pet meow; dog_as_pet fido])
+      ~resolve:(fun _ () -> [cat_as_pet meow; dog_as_pet fido])
     ;
     field "named_objects"
       ~typ:(non_null (list (non_null named)))
       ~args:Arg.[]
-      ~resolve:(fun () () -> [cat_as_named meow; dog_as_named fido])
+      ~resolve:(fun _ () -> [cat_as_named meow; dog_as_named fido])
   ])
 
 let test_query = Test_common.test_query schema ()

--- a/graphql/test/dune
+++ b/graphql/test/dune
@@ -11,7 +11,8 @@
   introspection_test
   error_test
   abstract_test)
- (libraries graphql alcotest))
+ (libraries graphql alcotest)
+ (flags (:standard -w -9)))
 
 (executable
  (libraries graphql_test)

--- a/graphql/test/echo_schema.ml
+++ b/graphql/test/echo_schema.ml
@@ -1,6 +1,6 @@
 open Graphql
 
-let echo : 'a. unit -> unit -> 'a -> 'a = fun _ _ x -> x
+let echo : 'a. unit Schema.resolve_params -> unit -> 'a -> 'a = fun _ _ x -> x
 
 let echo_field name field_typ arg_typ = Schema.(
       field name
@@ -42,13 +42,12 @@ let schema =
             ~args:Arg.[
               arg "x" ~typ:(non_null person_arg)
             ]
-            ~resolve:(fun () () (_, first, last) -> first ^ " " ^ last)
-            ;
+            ~resolve:(fun _ () (_, first, last) -> first ^ " " ^ last);
       field "sum_defaults"
             ~typ:int
             ~args:Arg.[
               arg' "x" ~typ:string ~default:"42";
               arg' "y" ~typ:int ~default:3
             ]
-            ~resolve:(fun () () x y -> try Some ((int_of_string x) + y) with _ -> None)
+            ~resolve:(fun _ () x y -> try Some ((int_of_string x) + y) with _ -> None)
   ])

--- a/graphql/test/test_schema.ml
+++ b/graphql/test/test_schema.ml
@@ -26,7 +26,7 @@ let user = Schema.(obj "user"
     field "id"
       ~typ:(non_null int)
       ~args:Arg.[]
-      ~resolve:(fun _ p -> p.id)
+      ~resolve:(fun { ctx = () } p -> p.id)
     ;
     field "name"
       ~typ:(non_null string)
@@ -75,7 +75,7 @@ let schema = Schema.(schema [
           arg' "raise" ~typ:bool ~default:false;
           arg' "first" ~typ:int ~default:1;
         ]
-        ~resolve:(fun () return_error raise_in_stream first ->
+        ~resolve:(fun _ return_error raise_in_stream first ->
           if return_error then
             Error "stream error"
           else if raise_in_stream then

--- a/graphql/test/test_schema.ml
+++ b/graphql/test/test_schema.ml
@@ -26,17 +26,17 @@ let user = Schema.(obj "user"
     field "id"
       ~typ:(non_null int)
       ~args:Arg.[]
-      ~resolve:(fun () p -> p.id)
+      ~resolve:(fun _ p -> p.id)
     ;
     field "name"
       ~typ:(non_null string)
       ~args:Arg.[]
-      ~resolve:(fun () p -> p.name)
+      ~resolve:(fun _ p -> p.name)
     ;
     field "role"
       ~typ:(non_null role)
       ~args:Arg.[]
-      ~resolve:(fun () p -> p.role)
+      ~resolve:(fun _ p -> p.role)
   ])
 )
 
@@ -52,7 +52,7 @@ let schema = Schema.(schema [
     field "users"
       ~typ:(non_null (list (non_null user)))
       ~args:Arg.[]
-      ~resolve:(fun () () -> !users)
+      ~resolve:(fun _ () -> !users)
     ]
     ~mutations:[
       field "add_user"
@@ -61,7 +61,7 @@ let schema = Schema.(schema [
           arg "name" ~typ:(non_null string);
           arg "role" ~typ:(non_null input_role)
         ]
-        ~resolve:(fun () () name role ->
+        ~resolve:(fun _ () name role ->
           let id = Random.int 1000000 in
           users := List.append !users [{ id; name; role }];
           !users


### PR DESCRIPTION
This is #82 and https://github.com/andreas/ocaml-graphql-server/tree/resolve-params rebased on current master.

It adds both variables and fragments to the resolve params. I could imagine this having more fields just like in the GraphQL reference implementation:

https://github.com/graphql/graphql-js/blob/26c9874107e65f19576aae0a32638287820f68aa/src/execution/execute.js#L97-L106