### PR TITLE
Improve error messages for invalid arguments

### DIFF
--- a/graphql/src/graphql_schema.ml
+++ b/graphql/src/graphql_schema.ml
@@ -156,6 +156,32 @@ module Make (Io : IO) (Stream: Stream with type 'a io = 'a Io.t) = struct
     let obj ?doc name ~fields ~coerce =
       Object { name; doc; fields; coerce }
 
+    let rec string_of_const_value: Graphql_parser.const_value -> string = function
+      | `Null -> "null"
+      | `Int i -> string_of_int(i)
+      | `Float f -> string_of_float(f)
+      | `String s -> Printf.sprintf "\"%s\"" s
+      | `Bool b -> string_of_bool(b)
+      | `Enum e -> e
+      | `List l -> Printf.sprintf "[%s]" (String.concat ", " (List.map (fun i -> (string_of_const_value i)) l))
+      | `Assoc a -> Printf.sprintf "{%s}" (String.concat ", " (List.map (fun (k, v) -> Printf.sprintf "%s: %s" k (string_of_const_value v)) a))
+
+     let rec string_of_arg_typ : type a. a arg_typ -> string = function
+      | Scalar(a) -> a.name
+      | Object(a) -> a.name
+      | Enum(a) -> a.name
+      | List(a) -> (Printf.sprintf "[%s]" (string_of_arg_typ a))
+      | NonNullable(a) -> (Printf.sprintf "%s!" (string_of_arg_typ a))
+
+     let eval_arg_error field_name arg_name arg_typ value =
+      Printf.sprintf "Argument `%s` of type `%s` expected on field `%s`, %s."
+                     arg_name
+                     (string_of_arg_typ arg_typ)
+                     field_name
+                     (match value with
+                     | Some(v) -> Printf.sprintf "found %s" (string_of_const_value v)
+                     | None -> "but not provided")
+
     (* Built-in argument types *)
     let int = Scalar {
       name = "Int";
@@ -215,13 +241,13 @@ module Make (Io : IO) (Stream: Stream with type 'a io = 'a Io.t) = struct
         let props' = List.map (fun (name, value) -> name, value_to_const_value variable_map value) props in
         `Assoc props'
 
-    let rec eval_arglist : type a b. variable_map -> (a, b) arg_list -> (string * Graphql_parser.value) list -> b -> (a, string) result =
-      fun variable_map arglist key_values f ->
+    let rec eval_arglist : type a b. variable_map -> string -> (a, b) arg_list -> (string * Graphql_parser.value) list -> b -> (a, string) result =
+      fun variable_map field_name arglist key_values f ->
         match arglist with
         | [] -> Ok f
         | (DefaultArg arg)::arglist' ->
             let arglist'' = (Arg { name = arg.name; doc = arg.doc; typ = arg.typ })::arglist' in
-            eval_arglist variable_map arglist'' key_values (function
+            eval_arglist variable_map field_name arglist'' key_values (function
               | None -> f arg.default
               | Some value -> f value
             )
@@ -229,14 +255,14 @@ module Make (Io : IO) (Stream: Stream with type 'a io = 'a Io.t) = struct
             try
               let value = List.assoc arg.name key_values in
               let const_value = Option.map value ~f:(value_to_const_value variable_map) in
-              eval_arg variable_map arg.typ const_value >>= fun coerced ->
-              eval_arglist variable_map arglist' key_values (f coerced)
+              eval_arg variable_map field_name arg.name arg.typ const_value >>= fun coerced ->
+              eval_arglist variable_map field_name arglist' key_values (f coerced)
             with StringMap.Missing_key key -> Error (Format.sprintf "Missing variable `%s`" key)
 
-    and eval_arg : type a. variable_map -> a arg_typ -> Graphql_parser.const_value option -> (a, string) result = fun variable_map typ value ->
+    and eval_arg : type a. variable_map -> string -> string -> a arg_typ -> Graphql_parser.const_value option -> (a, string) result = fun variable_map field_name arg_name typ value ->
       match (typ, value) with
-      | NonNullable _, None -> Error "Missing required argument"
-      | NonNullable _, Some `Null -> Error "Missing required argument"
+      | NonNullable _, None -> Error (eval_arg_error field_name arg_name typ value)
+      | NonNullable _, Some `Null -> Error (eval_arg_error field_name arg_name typ value)
       | Scalar _, None -> Ok None
       | Scalar _, Some `Null -> Ok None
       | Object _, None -> Ok None
@@ -246,38 +272,41 @@ module Make (Io : IO) (Stream: Stream with type 'a io = 'a Io.t) = struct
       | Enum _, None -> Ok None
       | Enum _, Some `Null -> Ok None
       | Scalar s, Some value ->
-          s.coerce value >>| fun coerced ->
-          Some coerced
+         let result = match (s.coerce value) with
+         | Ok coerced -> Ok (Some coerced)
+         | Error _ -> Error (eval_arg_error field_name arg_name typ (Some value))
+         in
+         result
       | Object o, Some value ->
           begin match value with
           | `Assoc props ->
               let props' = (props :> (string * Graphql_parser.value) list) in
-              eval_arglist variable_map o.fields props' o.coerce >>| fun coerced ->
+              eval_arglist variable_map field_name o.fields props' o.coerce >>| fun coerced ->
               Some coerced
-          | _ -> Error "Expected object"
+          | _ -> Error (eval_arg_error field_name arg_name typ (Some value))
           end
      | List typ, Some value ->
           begin match value with
           | `List values ->
               let option_values = List.map (fun x -> Some x) values in
-              List.Result.all (eval_arg variable_map typ) option_values >>| fun coerced ->
+              List.Result.all (eval_arg variable_map field_name arg_name typ) option_values >>| fun coerced ->
               Some coerced
-          | value -> eval_arg variable_map typ (Some value) >>| fun coerced ->
+          | value -> eval_arg variable_map field_name arg_name typ (Some value) >>| fun coerced ->
               (Some [coerced] : a)
           end
       | NonNullable typ, value ->
-          eval_arg variable_map typ value >>= (function
+          eval_arg variable_map field_name arg_name typ value >>= (function
           | Some value -> Ok value
-          | None -> Error "Missing required argument")
+          | None -> Error (eval_arg_error field_name arg_name typ None))
       | Enum e, Some value ->
           begin match value with
           | `Enum v
           | `String v ->
               begin match List.find (fun enum_value -> enum_value.name = v) e.values with
               | Some enum_value -> Ok (Some enum_value.value)
-              | None -> Error "Invalid enum value"
+              | None -> Error (Printf.sprintf "Invalid enum value for argument `%s` on field `%s`" arg_name field_name)
               end
-          | _ -> Error "Expected enum"
+          | _ -> Error (Printf.sprintf "Expected enum for argument `%s` on field `%s`" arg_name field_name)
           end
   end
 
@@ -1153,7 +1182,7 @@ end
       let name = alias_or_name query_field in
       let path' = (`String name)::path in
       let resolver = field.resolve ctx.ctx src in
-      match Arg.eval_arglist ctx.variables field.args query_field.arguments resolver with
+      match Arg.eval_arglist ctx.variables field.name field.args query_field.arguments resolver with
       | Ok unlifted_value ->
           let lifted_value =
             field.lift unlifted_value
@@ -1230,7 +1259,7 @@ end
       let name = alias_or_name field in
       let path = [`String name] in
       let resolver = subs_field.resolve ctx.ctx in
-      match Arg.eval_arglist ctx.variables subs_field.args field.arguments resolver with
+      match Arg.eval_arglist ctx.variables subs_field.name subs_field.args field.arguments resolver with
       | Ok result ->
           result
           |> Io.Result.map ~f:(fun source_stream ->

--- a/graphql/test/argument_test.ml
+++ b/graphql/test/argument_test.ml
@@ -71,7 +71,7 @@ let suite : (string * [>`Quick] * (unit -> unit)) list = [
       "data", `Null;
       "errors", `List [
         `Assoc [
-          "message", `String "Missing required argument"
+          "message", `String "Argument `x` of type `person!` expected on field `input_obj`, found null."
         ]
       ]
     ])
@@ -90,7 +90,7 @@ let suite : (string * [>`Quick] * (unit -> unit)) list = [
       "data", `Null;
       "errors", `List [
         `Assoc [
-          "message", `String "Missing required argument"
+          "message", `String "Argument `x` of type `person!` expected on field `input_obj`, but not provided."
         ]
       ]
     ])

--- a/graphql/test/variable_test.ml
+++ b/graphql/test/variable_test.ml
@@ -85,7 +85,7 @@ let suite : (string * [>`Quick] * (unit -> unit)) list = [
       "data", `Null;
       "errors", `List [
         `Assoc [
-          "message", `String "Missing required argument"
+          "message", `String "Argument `x` of type `person!` expected on field `input_obj`, found null."
         ]
       ]
     ])


### PR DESCRIPTION
I had a really hard time discovering the source of an error for a script that was making GraphQL queries to OneGraph. The error was "Invalid string", but I had multiple string arguments. 

With this change, the error I get back is ``Argument `pos` of type `String` expected on field `updateCard`, found 1.``

With that error, there is enough context for me to easily pinpoint the problem and fix it.

If you'd like an easy way to test, this change is live on OneGraph:

```
curl 'https://serve.onegraph.com/dynamic?app_id=0b33e830-7cde-4b90-ad7e-2a39c57c0e11'  \
    --data-binary '{"query":"{ trello { card { name }}}"}'

> {"data":null,"errors":[{"message":"Argument `id` of type `String!` expected on field `card`, but not provided."}]}
```