### PR TITLE
Add the `errors` key first in the response JSON

### DIFF
--- a/graphql/test/argument_test.ml
+++ b/graphql/test/argument_test.ml
@@ -68,12 +68,12 @@ let suite : (string * [>`Quick] * (unit -> unit)) list = [
   ("null for required argument", `Quick, fun () ->
     let query = "{ input_obj(x: null) }" in
     test_query query (`Assoc [
-      "data", `Null;
       "errors", `List [
         `Assoc [
           "message", `String "Argument `x` of type `person!` expected on field `input_obj`, found null."
         ]
-      ]
+      ];
+      "data", `Null;
     ])
   );
   ("missing optional argument", `Quick, fun () ->
@@ -87,12 +87,12 @@ let suite : (string * [>`Quick] * (unit -> unit)) list = [
   ("missing required argument", `Quick, fun () ->
     let query = "{ input_obj }" in
     test_query query (`Assoc [
-      "data", `Null;
       "errors", `List [
         `Assoc [
           "message", `String "Argument `x` of type `person!` expected on field `input_obj`, but not provided."
         ]
-      ]
+      ];
+      "data", `Null;
     ])
   );
   ("input coercion: single value to list", `Quick, fun () ->

--- a/graphql/test/error_test.ml
+++ b/graphql/test/error_test.ml
@@ -11,15 +11,15 @@ let suite = [
     ]) in
     let query = "{ nullable }" in
     test_query schema () query (`Assoc [
-      "data", `Assoc [
-        "nullable", `Null
-      ];
       "errors", `List [
         `Assoc [
           "message", `String "boom";
           "path", `List [`String "nullable"]
         ]
-      ]
+      ];
+      "data", `Assoc [
+        "nullable", `Null
+      ];
     ])
   );
   ("non-nullable error", `Quick, fun () ->
@@ -31,13 +31,13 @@ let suite = [
     ]) in
     let query = "{ non_nullable }" in
     test_query schema () query (`Assoc [
-      "data", `Null;
       "errors", `List [
         `Assoc [
           "message", `String "boom";
           "path", `List [`String "non_nullable"]
         ]
-      ]
+      ];
+      "data", `Null;
     ])
   );
   ("nested nullable error", `Quick, fun () ->
@@ -58,15 +58,15 @@ let suite = [
     in
     let query = "{ nullable { non_nullable } }" in
     test_query schema () query (`Assoc [
-      "data", `Assoc [
-        "nullable", `Null
-      ];
       "errors", `List [
         `Assoc [
           "message", `String "boom";
           "path", `List [`String "nullable"; `String "non_nullable"]
         ]
-      ]
+      ];
+      "data", `Assoc [
+        "nullable", `Null
+      ];
     ])
   );
   ("error in list", `Quick, fun () ->
@@ -91,6 +91,12 @@ let suite = [
     in
     let query = "{ foos { id } }" in
     test_query schema () query (`Assoc [
+      "errors", `List [
+        `Assoc [
+          "message", `String "boom";
+          "path", `List [`String "foos"; `Int 2; `String "id"]
+        ]
+      ];
       "data", `Assoc [
         "foos", `List [
           `Assoc [
@@ -104,12 +110,6 @@ let suite = [
           ];
         ]
       ];
-      "errors", `List [
-        `Assoc [
-          "message", `String "boom";
-          "path", `List [`String "foos"; `Int 2; `String "id"]
-        ]
-      ]
     ])
   );
 ]

--- a/graphql/test/schema_test.ml
+++ b/graphql/test/schema_test.ml
@@ -270,13 +270,13 @@ let suite = [
   ("subscription returns an error", `Quick, fun () ->
     let query = "subscription { subscribe_to_user(error: true) { id name } }" in
     test_query query (`Assoc [
-      "data", `Null;
       "errors", `List [
         `Assoc [
           "message", `String "stream error";
           "path", `List [`String "subscribe_to_user"]
         ]
-      ]
+      ];
+      "data", `Null;
     ])
   );
   ("subscriptions: exn inside the stream", `Quick, fun () ->

--- a/graphql/test/variable_test.ml
+++ b/graphql/test/variable_test.ml
@@ -82,12 +82,12 @@ let suite : (string * [>`Quick] * (unit -> unit)) list = [
     let variables = ["x", `Null] in
     let query = "{ input_obj(x: $x) }" in
     test_query variables query (`Assoc [
-      "data", `Null;
       "errors", `List [
         `Assoc [
           "message", `String "Argument `x` of type `person!` expected on field `input_obj`, found null."
         ]
-      ]
+      ];
+      "data", `Null;
     ])
   );
   ("variable coercion: single value to list", `Quick, fun () ->


### PR DESCRIPTION
According to the `Response Format`[section](https://facebook.github.io/graphql/June2018/#sec-Response-Format) of the GraphQL Spec:

> When errors is present in the response, it may be helpful for it to
appear first when serialized to make it more clear when errors are
present in a response during debugging.

refs #119