### PR TITLE
First stab at websockets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ env:
   - DISTRO="ubuntu-16.04" OCAML_VERSION="4.05" PACKAGE="graphql-async"
   - DISTRO="ubuntu-16.04" OCAML_VERSION="4.06" PACKAGE="graphql-async"
   - DISTRO="ubuntu-16.04" OCAML_VERSION="4.07" PACKAGE="graphql-async"
-  - DISTRO="ubuntu-16.04" OCAML_VERSION="4.03" PACKAGE="graphql-cohttp"
   - DISTRO="ubuntu-16.04" OCAML_VERSION="4.04" PACKAGE="graphql-cohttp"
   - DISTRO="ubuntu-16.04" OCAML_VERSION="4.05" PACKAGE="graphql-cohttp"
   - DISTRO="ubuntu-16.04" OCAML_VERSION="4.06" PACKAGE="graphql-cohttp"

--- a/examples/server.ml
+++ b/examples/server.ml
@@ -1,4 +1,4 @@
-open Lwt
+open Lwt.Infix
 open Graphql_lwt
 
 type role = User | Admin
@@ -106,11 +106,19 @@ let schema = Schema.(schema [
     ]
 )
 
-module Graphql_cohttp_lwt = Graphql_cohttp.Make (Graphql_lwt.Schema) (Cohttp_lwt.Body)
+module Graphql_cohttp_lwt = Graphql_cohttp.Make (Graphql_lwt.Schema) (Cohttp_lwt_unix.IO) (Cohttp_lwt.Body)
 
 let () =
+  let on_exn = function
+    | Unix.Unix_error (error, func, arg) ->
+      Logs.warn (fun m ->
+        m  "Client connection error %s: %s(%S)"
+          (Unix.error_message error) func arg
+      )
+    | exn -> Logs.err (fun m -> m "Unhandled exception: %a" Fmt.exn exn)
+  in
   let callback = Graphql_cohttp_lwt.make_callback (fun _req -> ()) schema in
-  let server = Cohttp_lwt_unix.Server.make ~callback () in
+  let server = Cohttp_lwt_unix.Server.make_response_action ~callback () in
   let mode = `TCP (`Port 8080) in
-  Cohttp_lwt_unix.Server.create ~mode server
+  Cohttp_lwt_unix.Server.create ~on_exn ~mode server
   |> Lwt_main.run

--- a/graphql-async/src/graphql_async.ml
+++ b/graphql-async/src/graphql_async.ml
@@ -9,6 +9,8 @@ module Schema = Graphql_schema.Make (struct
     let map t f = Async_kernel.Pipe.map' t ~f:(fun q ->
       Async_kernel.Deferred.Queue.map q ~f)
 
+    let iter t f = Async_kernel.Pipe.iter t ~f
+
     let close = Async_kernel.Pipe.close_read
   end
 end)

--- a/graphql-cohttp.opam
+++ b/graphql-cohttp.opam
@@ -15,8 +15,12 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "jbuilder" {build}
   "graphql" {>= "0.8.0"}
-  "cohttp" {>= "1.0.0"}
+  "cohttp" {>= "2.0.0"}
   "crunch"
+  "astring" {>= "0.8.3"}
+  "base64" {>= "3.0.0"}
+  "ocplib-endian" {>= "1.0"}
+  "digestif" {>= "0.7.0"}
 ]
 
 synopsis: "Run GraphQL servers with `cohttp`"

--- a/graphql-cohttp/src/assets/index.html
+++ b/graphql-cohttp/src/assets/index.html
@@ -18,11 +18,12 @@ add "&raw" to the end of the URL within a browser.
       width: 100%;
     }
   </style>
-  <link href="//cdn.jsdelivr.net/graphiql/0.8.1/graphiql.css" rel="stylesheet" />
-  <script src="//cdn.jsdelivr.net/fetch/0.9.0/fetch.min.js"></script>
-  <script src="//cdn.jsdelivr.net/react/15.3.2/react.min.js"></script>
-  <script src="//cdn.jsdelivr.net/react/15.3.2/react-dom.min.js"></script>
-  <script src="//cdn.jsdelivr.net/graphiql/0.8.1/graphiql.js"></script>
+  <link href="//cdn.jsdelivr.net/npm/graphiql@0.12.0/graphiql.css" rel="stylesheet" />
+  <script src="//cdn.jsdelivr.net/react/15.4.2/react.min.js"></script>
+  <script src="//cdn.jsdelivr.net/react/15.4.2/react-dom.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/graphiql@0.12.0/graphiql.js"></script>
+  <script src="//unpkg.com/subscriptions-transport-ws@0.8.1/browser/client.js"></script>
+  <script src="//unpkg.com/graphiql-subscriptions-fetcher@0.0.2/browser/client.js"></script>
 </head>
 <body>
   <script>
@@ -98,10 +99,14 @@ add "&raw" to the end of the URL within a browser.
       history.replaceState(null, null, locationQuery(parameters));
     }
 
+    var subscriptionsClient = new SubscriptionsTransportWs.SubscriptionClient('ws://' + window.location.host + window.location.pathname, { reconnect: true });
+
+    var subscriptionsFetcher = GraphiQLSubscriptionsFetcher.graphQLFetcher(subscriptionsClient, graphQLFetcher);
+
     // Render <GraphiQL /> into the body.
     ReactDOM.render(
       React.createElement(GraphiQL, {
-        fetcher: graphQLFetcher,
+        fetcher: subscriptionsFetcher,
         onEditQuery: onEditQuery,
         onEditVariables: onEditVariables,
         onEditOperationName: onEditOperationName,

--- a/graphql-cohttp/src/dune
+++ b/graphql-cohttp/src/dune
@@ -7,4 +7,4 @@
  (name graphql_cohttp)
  (public_name graphql-cohttp)
  (wrapped false)
- (libraries str graphql cohttp))
+ (libraries str graphql cohttp astring base64 ocplib-endian digestif.ocaml))

--- a/graphql-cohttp/src/graphql_cohttp.ml
+++ b/graphql-cohttp/src/graphql_cohttp.ml
@@ -6,22 +6,62 @@ module type HttpBody = sig
   val of_string : string -> t
 end
 
+module type S = sig
+  module IO : Cohttp.S.IO
+  type body
+  type 'ctx schema
+
+  type response_action =
+    [ `Expert of Cohttp.Response.t
+                 * (IO.ic
+                    -> IO.oc
+                    -> unit IO.t)
+    | `Response of Cohttp.Response.t * body ]
+
+  type 'conn callback =
+    'conn ->
+    Cohttp.Request.t ->
+    body ->
+    response_action IO.t
+
+  val execute_request :
+    'ctx schema ->
+    'ctx ->
+    Cohttp.Request.t ->
+    body ->
+    response_action IO.t
+
+  val make_callback :
+    (Cohttp.Request.t -> 'ctx) ->
+    'ctx schema ->
+    'conn callback
+end
+
 module Make
   (Schema : Graphql_intf.Schema)
+  (Io : Cohttp.S.IO with type 'a t = 'a Schema.Io.t)
   (Body : HttpBody with type +'a io := 'a Schema.Io.t) = struct
 
-  module Io = Schema.Io
+  module Ws = Websocket.Connection.Make (Io)
+  module Websocket_transport = Websocket_handler.Make (Schema.Io) (Ws)
 
-  let (>>=) = Io.bind
+  let (>>=) = Io.(>>=)
+
+  type response_action =
+    [ `Expert of Cohttp.Response.t
+                 * (Io.ic
+                    -> Io.oc
+                    -> unit Io.t)
+    | `Response of Cohttp.Response.t * Body.t ]
 
   type 'conn callback =
     'conn ->
     Cohttp.Request.t ->
     Body.t ->
-    (Cohttp.Response.t * Body.t) Schema.Io.t
+    response_action Io.t
 
   let respond_string ~status ~body () =
-    Io.return (Cohttp.Response.make ~status (), Body.of_string body)
+    Io.return (`Response (Cohttp.Response.make ~status (), Body.of_string body))
 
   let static_file_response path =
     match Assets.read path with
@@ -57,11 +97,16 @@ module Make
       let body = Yojson.Basic.to_string err in
       respond_string ~status:`Internal_server_error ~body ()
 
-  let make_callback make_context schema _conn (req : Cohttp.Request.t) body =
+  let make_callback : (Cohttp.Request.t -> 'ctx) -> 'ctx Schema.schema -> 'conn callback = fun make_context schema _conn (req : Cohttp.Request.t) body ->
     let req_path = Cohttp.Request.uri req |> Uri.path in
     let path_parts = Str.(split (regexp "/") req_path) in
     match req.meth, path_parts with
-    | `GET,  ["graphql"]       -> static_file_response "index.html"
+    | `GET,  ["graphql"] ->
+      if Cohttp.Header.get req.Cohttp.Request.headers "Connection" = Some "Upgrade" && Cohttp.Header.get req.headers "Upgrade" = Some "websocket" then
+        let handle_conn =  Websocket_transport.handle (execute_query (make_context req) schema) in
+        Io.return (Ws.upgrade_connection req handle_conn)
+      else
+        static_file_response "index.html"
     | `GET,  ["graphql"; path] -> static_file_response path
     | `POST, ["graphql"]       -> execute_request schema (make_context req) req body
     | _ -> respond_string ~status:`Not_found ~body:"" ()

--- a/graphql-cohttp/src/graphql_cohttp.mli
+++ b/graphql-cohttp/src/graphql_cohttp.mli
@@ -6,25 +6,41 @@ module type HttpBody = sig
   val of_string : string -> t
 end
 
-module Make
-  (Schema : Graphql_intf.Schema)
-  (Body : HttpBody with type +'a io := 'a Schema.Io.t) : sig
+module type S = sig
+  module IO : Cohttp.S.IO
+  type body
+  type 'ctx schema
+
+  type response_action =
+    [ `Expert of Cohttp.Response.t
+                 * (IO.ic
+                    -> IO.oc
+                    -> unit IO.t)
+    | `Response of Cohttp.Response.t * body ]
 
   type 'conn callback =
     'conn ->
     Cohttp.Request.t ->
-    Body.t ->
-    (Cohttp.Response.t * Body.t) Schema.Io.t
+    body ->
+    response_action IO.t
 
   val execute_request :
-    'ctx Schema.schema ->
+    'ctx schema ->
     'ctx ->
     Cohttp.Request.t ->
-    Body.t ->
-    (Cohttp.Response.t * Body.t) Schema.Io.t
+    body ->
+    response_action IO.t
 
   val make_callback :
     (Cohttp.Request.t -> 'ctx) ->
-    'ctx Schema.schema ->
+    'ctx schema ->
     'conn callback
 end
+
+module Make
+  (Schema : Graphql_intf.Schema)
+  (IO : Cohttp.S.IO with type 'a t = 'a Schema.Io.t)
+  (Body : HttpBody with type +'a io := 'a Schema.Io.t) :
+  S with type 'ctx schema := 'ctx Schema.schema
+     and module IO := IO
+     and type body := Body.t

--- a/graphql-cohttp/src/websocket.ml
+++ b/graphql-cohttp/src/websocket.ml
@@ -1,0 +1,361 @@
+(*
+ * Copyright (c) 2012-2018 Vincent Bernardoff <vb@luminar.eu.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ *)
+
+open Astring
+
+let b64_encoded_sha1sum s =
+  s
+  |> Digestif.SHA1.digest_string
+  |> Digestif.SHA1.to_raw_string
+  |> Base64.encode_exn ~pad:true
+
+let websocket_uuid = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+
+module Frame = struct
+  module Opcode = struct
+    type t =
+      | Continuation
+      | Text
+      | Binary
+      | Close
+      | Ping
+      | Pong
+      | Ctrl of int
+      | Nonctrl of int
+
+    let to_string = function
+    | Continuation -> "continuation"
+    | Text -> "text"
+    | Binary -> "binary"
+    | Close -> "close"
+    | Ping -> "ping"
+    | Pong -> "pong"
+    | Ctrl i -> "ctrl " ^ string_of_int i
+    | Nonctrl i -> "nonctrl " ^ string_of_int i
+
+    let pp ppf t = Format.fprintf ppf "%s" (to_string t)
+
+    let of_enum = function
+      | i when (i < 0 || i > 0xf) -> invalid_arg "Frame.Opcode.of_enum"
+      | 0                         -> Continuation
+      | 1                         -> Text
+      | 2                         -> Binary
+      | 8                         -> Close
+      | 9                         -> Ping
+      | 10                        -> Pong
+      | i when i < 8              -> Nonctrl i
+      | i                         -> Ctrl i
+
+    let to_enum = function
+      | Continuation   -> 0
+      | Text           -> 1
+      | Binary         -> 2
+      | Close          -> 8
+      | Ping           -> 9
+      | Pong           -> 10
+      | Ctrl i         -> i
+      | Nonctrl i      -> i
+
+    let is_ctrl opcode = to_enum opcode > 7
+  end
+
+  type t = {
+    opcode: Opcode.t;
+    extension: int;
+    final: bool;
+    content: string;
+  }
+
+  let pp ppf { opcode ; extension ; final ; content } =
+    Format.fprintf ppf
+      "[%a (0x%x) (final=%b) %s]" Opcode.pp opcode extension final content
+
+  let show t = Format.asprintf "%a" pp t
+
+  let create
+      ?(opcode = Opcode.Text) ?(extension=0) ?(final=true) ?(content="") () =
+    { opcode ; extension ; final ; content }
+
+  let of_bytes ?opcode ?extension ?final content =
+    let content = Bytes.unsafe_to_string content in
+    create ?opcode ?extension ?final ~content ()
+
+  let close code =
+    let content = Bytes.create 2 in
+    EndianBytes.BigEndian.set_int16 content 0 code;
+    of_bytes ~opcode:Opcode.Close content
+end
+
+module Bits = struct
+  let xor mask msg =
+    for i = 0 to Bytes.length msg - 1 do (* masking msg to send *)
+      Bytes.set msg i Char.(to_int mask.[i mod 4] lxor to_int (Bytes.get msg i) |> of_byte)
+    done
+
+  let is_bit_set idx v =
+    (v lsr idx) land 1 = 1
+
+  let set_bit v idx b =
+    if b then v lor (1 lsl idx) else v land (lnot (1 lsl idx))
+
+  let int_value shift len v = (v lsr shift) land ((1 lsl len) - 1)
+end
+
+exception Protocol_error of string
+
+module Connection = struct
+  type mode =
+    | Client of (int -> string)
+    | Server
+
+  module type S = sig
+    module IO : Cohttp.S.IO
+    type t
+
+    val create :
+      ?read_buf:Buffer.t ->
+      ?write_buf:Buffer.t ->
+      mode:mode ->
+      Cohttp.Request.t ->
+      IO.ic ->
+      IO.oc ->
+      t
+
+    val send : t -> Frame.t -> unit IO.t
+    val send_multiple : t -> Frame.t list -> unit IO.t
+    val recv : t -> Frame.t IO.t
+    val req : t -> Cohttp.Request.t
+
+    val upgrade_connection :
+      ?read_buf : Buffer.t ->
+      ?write_buf : Buffer.t ->
+      Cohttp.Request.t ->
+      (t -> unit IO.t) ->
+      [> `Expert of Cohttp.Response.t * (IO.ic -> IO.oc -> unit IO.t) ]
+  end
+
+  module Make (IO : Cohttp.S.IO) = struct
+    module IO = IO
+    let (>>=) = IO.(>>=)
+
+    let is_client mode = mode <> Server
+
+    let rec read_exactly ic remaining buf =
+      IO.read ic remaining >>= fun s ->
+      if s = "" then
+        IO.return None
+      else
+        let recv_len = String.length s in
+        Buffer.add_string buf s;
+        if remaining - recv_len <= 0 then
+          IO.return @@ Some (Buffer.contents buf)
+        else
+          read_exactly ic (remaining - recv_len) buf
+
+    let read_uint16 ic buf =
+      read_exactly ic 2 buf >>= fun s ->
+      match s with
+      | None ->
+          IO.return None
+      | Some s ->
+          IO.return @@ Some (EndianString.BigEndian.get_uint16 s 0)
+
+    let read_int64 ic buf =
+      read_exactly ic 8 buf >>= fun s ->
+      match s with
+      | None ->
+          IO.return None
+      | Some s ->
+          IO.return @@ Some (Int64.to_int @@ EndianString.BigEndian.get_int64 s 0)
+
+    let write_frame_to_buf ~mode buf fr =
+      let open Frame in
+      let scratch = Bytes.create 8 in
+      let content = Bytes.unsafe_of_string fr.content in
+      let len = Bytes.length content in
+      let opcode = Opcode.to_enum fr.opcode in
+      let payload_len = match len with
+        | n when n < 126      -> len
+        | n when n < 1 lsl 16 -> 126
+        | _                   -> 127
+      in
+      let hdr = Bits.set_bit 0 15 (fr.final) in (* We do not support extensions for now *)
+      let hdr = hdr lor (opcode lsl 8) in
+      let hdr = Bits.set_bit hdr 7 (is_client mode) in
+      let hdr = hdr lor payload_len in (* Payload len is guaranteed to fit in 7 bits *)
+      EndianBytes.BigEndian.set_int16 scratch 0 hdr;
+      Buffer.add_subbytes buf scratch 0 2;
+      begin match len with
+       | n when n < 126 -> ()
+       | n when n < (1 lsl 16) ->
+         EndianBytes.BigEndian.set_int16 scratch 0 n;
+         Buffer.add_subbytes buf scratch 0 2
+       | n ->
+         EndianBytes.BigEndian.set_int64 scratch 0 Int64.(of_int n);
+         Buffer.add_subbytes buf scratch 0 8;
+      end;
+      begin match mode with
+      | Server -> ()
+      | Client random_string ->
+        let mask = random_string 4 in
+        Buffer.add_string buf mask;
+        if len > 0 then Bits.xor mask content;
+      end;
+      Buffer.add_bytes buf content
+
+    let close_with_code mode buf oc code =
+      Buffer.clear buf;
+      write_frame_to_buf ~mode buf @@ Frame.close code;
+      IO.write oc @@ Buffer.contents buf
+
+    let make_read_frame ?(buf=Buffer.create 128) ~mode ic oc = fun () ->
+      Buffer.clear buf;
+      read_exactly ic 2 buf >>= fun hdr ->
+      match hdr with
+      | None -> raise End_of_file
+      | Some hdr ->
+        let hdr_part1 = EndianString.BigEndian.get_int8 hdr 0 in
+        let hdr_part2 = EndianString.BigEndian.get_int8 hdr 1 in
+        let final = Bits.is_bit_set 7 hdr_part1 in
+        let extension = Bits.int_value 4 3 hdr_part1 in
+        let opcode = Bits.int_value 0 4 hdr_part1 in
+        let frame_masked = Bits.is_bit_set 7 hdr_part2 in
+        let length = Bits.int_value 0 7 hdr_part2 in
+        let opcode = Frame.Opcode.of_enum opcode in
+        Buffer.clear buf;
+        (match length with
+        | i when i < 126 -> IO.return i
+        | 126 -> (read_uint16 ic buf >>= function Some i -> IO.return i | None -> IO.return @@ -1)
+        | 127 -> (read_int64 ic buf >>= function Some i -> IO.return i | None -> IO.return @@ -1)
+        | _ -> IO.return @@ -1
+        ) >>= fun payload_len ->
+        if payload_len = -1 then
+          raise (Protocol_error ("payload len = " ^ string_of_int length))
+        else if extension <> 0 then
+          close_with_code mode buf oc 1002 >>= fun () ->
+          raise (Protocol_error "unsupported extension")
+        else if Frame.Opcode.is_ctrl opcode && payload_len > 125 then
+          close_with_code mode buf oc 1002 >>= fun () ->
+          raise (Protocol_error "control frame too big")
+        else
+        (if frame_masked then
+           (Buffer.clear buf;
+            read_exactly ic 4 buf >>= function
+            | None -> raise (Protocol_error "could not read mask");
+            | Some mask -> IO.return mask)
+         else IO.return String.empty) >>= fun mask ->
+        if payload_len = 0 then
+          IO.return @@ Frame.create ~opcode ~extension ~final ()
+        else
+        (Buffer.clear buf;
+         read_exactly ic payload_len buf) >>= fun payload ->
+        match payload with
+        | None -> raise (Protocol_error "could not read payload")
+        | Some payload ->
+          let payload = Bytes.unsafe_of_string payload in
+          if frame_masked then Bits.xor mask payload;
+          let frame = Frame.of_bytes ~opcode ~extension ~final payload in
+          IO.return frame
+
+    type t = {
+      buffer: Buffer.t;
+      ic: IO.ic;
+      oc: IO.oc;
+      req : Cohttp.Request.t;
+      read_frame: unit -> Frame.t IO.t;
+    }
+
+    let create
+        ?read_buf
+        ?(write_buf=Buffer.create 128)
+        ~mode
+        req
+        ic oc =
+      let read_frame = make_read_frame ?buf:read_buf ~mode ic oc in
+      {
+        buffer = write_buf;
+        ic;
+        oc;
+        req;
+        read_frame;
+      }
+
+    let req t = t.req
+
+    let send { buffer; oc; _ } frame =
+      Buffer.clear buffer;
+      write_frame_to_buf ~mode:Server buffer frame;
+      IO.write oc @@ Buffer.contents buffer
+
+    let send_multiple { buffer; oc; _ } frames =
+      Buffer.clear buffer;
+      List.iter (write_frame_to_buf ~mode:Server buffer) frames;
+      IO.write oc @@ Buffer.contents buffer
+
+    let recv t =
+      t.read_frame () >>= fun fr ->
+      match fr.Frame.opcode with
+      | Frame.Opcode.Ping ->
+        send t @@ Frame.create ~opcode:Frame.Opcode.Pong () >>= fun () ->
+        IO.return fr
+      | Frame.Opcode.Close ->
+        (* Immediately echo and pass this last message to the user *)
+        (if String.length fr.Frame.content >= 2 then
+           send t @@ Frame.create
+             ~opcode:Frame.Opcode.Close
+             ~content:(String.(sub ~start:0 ~stop:2 fr.Frame.content |> Sub.to_string)) ()
+         else
+           send t @@ Frame.close 1000
+        ) >>= fun () ->
+        IO.return fr
+      | _ ->
+        IO.return fr
+
+    let upgrade_connection ?read_buf ?write_buf request handle_conn =
+      let headers = Cohttp.Request.headers request in
+      let key = match Cohttp.Header.get headers "sec-websocket-key" with
+      | None -> failwith "upgrade_connection: missing header \
+                              `sec-websocket-key`"
+      | Some key -> key
+      in
+      let subprotocol = match Cohttp.Header.get headers "sec-websocket-protocol" with
+      | None -> []
+      | Some p -> ["Sec-WebSocket-Protocol", p]
+      in
+      let hash = b64_encoded_sha1sum (key ^ websocket_uuid) in
+      let response_headers =
+        Cohttp.Header.of_list
+          (("Upgrade", "websocket") ::
+          ("Connection", "Upgrade") ::
+          ("Sec-WebSocket-Accept", hash) ::
+          subprotocol)
+      in
+      let rsp =
+          Cohttp.Response.make
+            ~status:`Switching_protocols
+            ~encoding:Cohttp.Transfer.Unknown
+            ~headers:response_headers
+            ~flush:true
+            ()
+      in
+      let io_handler ic oc =
+        let client = create ?read_buf ?write_buf ~mode:Server request ic oc in
+        handle_conn client
+      in
+      `Expert (rsp, io_handler)
+  end
+end

--- a/graphql-cohttp/src/websocket.mli
+++ b/graphql-cohttp/src/websocket.mli
@@ -1,0 +1,82 @@
+(*
+ * Copyright (c) 2012-2018 Vincent Bernardoff <vb@luminar.eu.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ *)
+
+exception Protocol_error of string
+
+module Frame : sig
+  module Opcode : sig
+    type t =
+      | Continuation
+      | Text
+      | Binary
+      | Close
+      | Ping
+      | Pong
+      | Ctrl of int
+      | Nonctrl of int
+
+    val to_string : t -> string
+    val pp : Format.formatter -> t -> unit
+  end
+
+  type t = {
+    opcode: Opcode.t ;
+    extension: int ;
+    final: bool ;
+    content: string ;
+  }
+
+  val create :
+    ?opcode:Opcode.t ->
+    ?extension:int ->
+    ?final:bool ->
+    ?content:string ->
+    unit -> t
+
+  val close : int -> t
+  val show : t -> string
+end
+
+module Connection : sig
+  type mode =
+    | Client of (int -> string)
+    | Server
+
+  module type S = sig
+    module IO : Cohttp.S.IO
+
+    type t
+
+    val create :
+      ?read_buf:Buffer.t -> ?write_buf:Buffer.t ->
+      mode:mode -> Cohttp.Request.t -> IO.ic -> IO.oc -> t
+
+    val send : t -> Frame.t -> unit IO.t
+    val send_multiple : t -> Frame.t list -> unit IO.t
+    val recv : t -> Frame.t IO.t
+    val req : t -> Cohttp.Request.t
+
+    val upgrade_connection :
+      ?read_buf : Buffer.t ->
+      ?write_buf : Buffer.t ->
+      Cohttp.Request.t ->
+      (t -> unit IO.t) ->
+      [> `Expert of Cohttp.Response.t * (IO.ic -> IO.oc -> unit IO.t) ]
+  end
+
+  module Make (IO : Cohttp.S.IO) : S with module IO = IO
+end

--- a/graphql-cohttp/src/websocket_handler.ml
+++ b/graphql-cohttp/src/websocket_handler.ml
@@ -1,0 +1,133 @@
+module Make (IO : Graphql_intf.IO) (Ws : Websocket.Connection.S with type 'a IO.t = 'a IO.t) = struct
+  module Json = Yojson.Basic.Util
+
+  let (>>=) = IO.bind
+
+  type t = {
+    conn : Ws.t;
+    subscriptions : (string, unit -> unit) Hashtbl.t;
+  }
+
+  type client_message =
+    | Gql_connection_init
+    | Gql_start of {
+        id : string;
+        query : string;
+        variables : (string * Graphql_parser.const_value) list option;
+        operation_name : string option;
+      }
+    | Gql_stop of {
+        id : string;
+      }
+    | Gql_connection_terminate
+
+  type server_message =
+    | Gql_connection_error
+    | Gql_connection_ack
+    | Gql_data
+    | Gql_error
+    | Gql_complete
+ (* | Gql_connection_keep_alive *)
+
+    let client_message_of_payload msg =
+      match msg |> Json.member "type" |> Json.to_string_option with
+      | Some "connection_init" ->
+          Ok Gql_connection_init
+      | Some "start" ->
+          let id = Json.(msg |> member "id" |> to_string) in
+          let payload = Json.member "payload" msg in
+          let query = Json.(payload |> member "query" |> to_string) in
+          let variables = Json.(payload |> member "variables" |> to_option to_assoc) in
+          let variables = (variables :> (string * Graphql_parser.const_value) list option) in
+          let operation_name = Json.(payload |> member "operationName" |> to_string_option)
+          in
+          Ok (Gql_start { id; query; variables; operation_name })
+      | Some "stop" ->
+          let id = Json.(member "id" msg |> to_string) in
+          Ok (Gql_stop { id })
+      | Some "connection_terminate" ->
+          Ok Gql_connection_terminate
+      | Some typ ->
+          Error (Format.sprintf "Unknown message type `%s`" typ)
+      | None ->
+          Error (Format.sprintf "Missing message type")
+
+    let server_message_to_string = function
+      | Gql_connection_error -> "connection_error"
+      | Gql_connection_ack -> "connection_ack"
+      | Gql_data -> "data"
+      | Gql_error -> "error"
+      | Gql_complete -> "complete"
+    (* | Gql_connection_keep_alive -> "ka" *)
+
+    let create_message ?(opcode=Websocket.Frame.Opcode.Text) ?id ?(payload=`Null) typ =
+      let frame_payload = `Assoc [
+          "type", `String (server_message_to_string typ);
+          "id", begin match id with
+            | Some id -> `String id
+            | None -> `Null end;
+          "payload", payload
+        ] in
+      let content = Yojson.Basic.to_string frame_payload in
+      Websocket.Frame.create ~opcode ~content ()
+
+    let handle_frame t ~execute_query frame =
+      match frame.Websocket.Frame.opcode with
+      | Ping
+      | Pong
+      | Close
+      | Ctrl _
+      | Nonctrl _ ->
+        IO.return ()
+      | Continuation
+      | Text
+      | Binary ->
+        let json = Yojson.Basic.from_string frame.Websocket.Frame.content in
+        match client_message_of_payload json with
+        | Ok Gql_connection_init ->
+          Ws.send t.conn (create_message Gql_connection_ack);
+        | Ok (Gql_start { id; query; variables; operation_name }) ->
+          execute_query
+            variables
+            operation_name
+            query
+          >>= (function
+          | Error message ->
+            let payload = `Assoc ["message", message] in
+            Ws.send t.conn (create_message ~payload ~id Gql_error)
+          | Ok (`Response payload) ->
+            Ws.send t.conn (create_message ~id ~payload Gql_data)
+          | Ok (`Stream stream) ->
+            let close () = IO.Stream.close stream in
+            Hashtbl.add t.subscriptions id close;
+            IO.Stream.iter stream (fun response ->
+              let Ok payload | Error payload = response in
+              Ws.send t.conn (create_message ~id ~payload Gql_data)
+            ) >>= fun () ->
+            Ws.send t.conn (create_message ~id Gql_complete)
+          )
+        | Ok (Gql_stop { id }) ->
+          begin try
+            let close = Hashtbl.find t.subscriptions id in
+            close ()
+          with Not_found -> ()
+          end;
+          IO.return ()
+        | Ok Gql_connection_terminate ->
+          Hashtbl.iter (fun _id close -> close ()) t.subscriptions;
+          Ws.send t.conn (create_message ~opcode:Websocket.Frame.Opcode.Close Gql_connection_error)
+        | Error msg ->
+          let id = Json.(json |> member "id" |> to_string) in
+          let payload = `Assoc ["message", `String msg] in
+          Ws.send t.conn (create_message ~id ~payload Gql_error)
+
+    let handle execute_query conn =
+      let subscriptions = Hashtbl.create 8 in
+      let t = { conn; subscriptions } in
+      let rec loop () =
+        Ws.recv conn >>= fun frame ->
+        handle_frame t ~execute_query frame >>= fun () ->
+        loop ()
+      in
+      loop ()
+end

--- a/graphql-lwt/src/graphql_lwt.ml
+++ b/graphql-lwt/src/graphql_lwt.ml
@@ -5,6 +5,7 @@ module Schema = Graphql_schema.Make (struct
     type 'a t = 'a Lwt_stream.t * (unit -> unit)
 
     let map (t, close) f = (Lwt_stream.map_s f t, close)
+    let iter (t, _close) f = Lwt_stream.iter_s f t
     let close (_, close) = close ()
   end
 end)

--- a/graphql/src/graphql.ml
+++ b/graphql/src/graphql.ml
@@ -8,6 +8,7 @@ module Schema = Graphql_schema.Make (struct
     type 'a t = 'a Seq.t
 
     let map t f = Seq.map f t
+    let iter t f = Seq.iter f t
     let close _t = ()
   end
 end)

--- a/graphql/src/graphql_intf.ml
+++ b/graphql/src/graphql_intf.ml
@@ -10,6 +10,7 @@ module type IO = sig
     type +'a io
 
     val map : 'a t -> ('a -> 'b io) -> 'b t
+    val iter : 'a t -> ('a -> unit io) -> unit io
     val close : 'a t -> unit
   end with type 'a io := 'a t
 end

--- a/graphql/src/graphql_schema.ml
+++ b/graphql/src/graphql_schema.ml
@@ -34,6 +34,7 @@ module type IO = sig
     type 'a t
 
     val map : 'a t -> ('a -> 'b io) -> 'b t
+    val iter : 'a t -> ('a -> unit io) -> unit io
     val close : 'a t -> unit
   end with type 'a io := 'a t
 end


### PR DESCRIPTION
This PR is the first stab at adding a websocket transport ([protocol documentation](https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md)). It's based on the following:

- [`anmonteiro/ocaml-subscriptions-transport-ws`](https://github.com/anmonteiro/ocaml-subscriptions-transport-ws), from which I've taken the main protocol handling and edited somewhat.
- [`vbmithr/ocaml-websocket`](https://github.com/vbmithr/ocaml-websocket), which has been simplified and made Mirage-compatible based on the thoughts [in this issue](https://github.com/vbmithr/ocaml-websocket/issues/105) and the work on [response actions for Cohttp_lwt](https://github.com/mirage/ocaml-cohttp/pull/647).

Note that this PR requires pinning `cohttp` to `master` until a new release is out.

The code generally needs some more spit'n polish, but it's in a workable state now.