### PR TITLE
Use Format for pretty-printing instead of Fmt

### DIFF
--- a/graphql_parser.opam
+++ b/graphql_parser.opam
@@ -17,7 +17,6 @@ depends: [
   "menhir" {build}
   "alcotest" {with-test & >= "0.8.1"}
   "result"
-  "fmt"
 ]
 
 synopsis: "Library for parsing GraphQL queries"

--- a/graphql_parser/src/dune
+++ b/graphql_parser/src/dune
@@ -7,5 +7,5 @@
 (library
  (name graphql_parser)
  (public_name graphql_parser)
- (libraries result fmt str)
+ (libraries result str)
  (flags (:standard -w -30)))

--- a/graphql_parser/src/graphql_parser.mli
+++ b/graphql_parser/src/graphql_parser.mli
@@ -61,13 +61,13 @@ type fragment =
     directives : directive list;
     selection_set : selection list;
   }
- 
+
 
 type typ =
   | NamedType of string
   | ListType of typ
   | NonNullType of typ
- 
+
 
 type variable_definition =
   {
@@ -99,4 +99,4 @@ type document =
 
 val parse : string -> (document, string) result
 
-val pp_document : document Fmt.t
+val pp_document : Format.formatter -> document -> unit

--- a/graphql_parser/test/parser_test.ml
+++ b/graphql_parser/test/parser_test.ml
@@ -1,4 +1,4 @@
-let graphql_query = Alcotest.testable Fmt.string (fun a b ->
+let graphql_query = Alcotest.testable Format.pp_print_string (fun a b ->
   let graphql_ignored = Str.regexp "[ ,\t\r\n]" in
   let strip = Str.global_replace graphql_ignored "" in
   (strip a) = (strip b)
@@ -7,7 +7,7 @@ let graphql_query = Alcotest.testable Fmt.string (fun a b ->
 let test_query query =
   match Graphql_parser.parse query with
   | Ok doc ->
-      let query' = Fmt.to_to_string Graphql_parser.pp_document doc in
+      let query' = Format.asprintf "%a" Graphql_parser.pp_document doc in
       Alcotest.check graphql_query "Parse result" query query'
   | Error err ->
       Alcotest.failf "Failed to parse %s: %s" query err
@@ -222,7 +222,7 @@ let test_keywords () =
 
 let test_escaped_string () =
   test_query {|
-    {	
+    {
       escaped_quote(x: "\"")
       backslash(x: "\\")
       slash(x: "/")


### PR DESCRIPTION
This is probably a bit random, but I replaced `Fmt` with the standard `Format` module. One less dependency, plus if you like `printf` you might find this more readable.

I hope to get onto something more useful (like block strings) soon