### PR TITLE
Replace str with re

### DIFF
--- a/graphql_parser.opam
+++ b/graphql_parser.opam
@@ -16,7 +16,6 @@ depends: [
   "dune" {build}
   "menhir" {build}
   "alcotest" {with-test & >= "0.8.1"}
-  "result"
   "fmt"
   "re" {>= "1.5.0"}
 ]

--- a/graphql_parser.opam
+++ b/graphql_parser.opam
@@ -18,6 +18,7 @@ depends: [
   "alcotest" {with-test & >= "0.8.1"}
   "result"
   "fmt"
+  "re" {>= "1.5.0"}
 ]
 
 synopsis: "Library for parsing GraphQL queries"

--- a/graphql_parser/src/ast.ml
+++ b/graphql_parser/src/ast.ml
@@ -99,16 +99,16 @@ module Pp = struct
   let comma = Fmt.(const string ",")
   let colon = Fmt.(const string ":")
 
-  let quote_string str =
-    let open Str in
-    str
-    |> global_replace (regexp "\\") "\\\\\\\\"
-    |> global_replace (regexp "\"") "\\\""
-    |> global_replace (regexp "\b") "\\b"
-    |> global_replace (regexp "\012") "\\f"
-    |> global_replace (regexp "\n") "\\n"
-    |> global_replace (regexp "\r") "\\r"
-    |> global_replace (regexp "\t") "\\t"
+  let quote_string s =
+    let open Re in
+    s
+    |> replace_string (compile (char '\\'))   ~by:"\\\\"
+    |> replace_string (compile (char '"'))    ~by:"\\\""
+    |> replace_string (compile (char '\b'))   ~by:"\\b"
+    |> replace_string (compile (char '\012')) ~by:"\\f"
+    |> replace_string (compile (char '\n'))   ~by:"\\n"
+    |> replace_string (compile (char '\r'))   ~by:"\\r"
+    |> replace_string (compile (char '\t'))   ~by:"\\t"
 
   let rec pp_value fmt = function
     | `Null -> Fmt.string fmt "null"

--- a/graphql_parser/src/dune
+++ b/graphql_parser/src/dune
@@ -7,5 +7,5 @@
 (library
  (name graphql_parser)
  (public_name graphql_parser)
- (libraries result fmt str)
+ (libraries result fmt re)
  (flags (:standard -w -30)))

--- a/graphql_parser/src/dune
+++ b/graphql_parser/src/dune
@@ -7,5 +7,5 @@
 (library
  (name graphql_parser)
  (public_name graphql_parser)
- (libraries result fmt re)
+ (libraries fmt re)
  (flags (:standard -w -30)))


### PR DESCRIPTION
`Str` is not available on MirageOS freestanding, so replacing with `Re`.

See https://github.com/mirage/irmin/issues/632