### PR TITLE
Remove Str from cohttp-graphql

### DIFF
--- a/graphql-cohttp/src/dune
+++ b/graphql-cohttp/src/dune
@@ -7,4 +7,4 @@
  (name graphql_cohttp)
  (public_name graphql-cohttp)
  (wrapped false)
- (libraries str graphql cohttp astring base64 ocplib-endian digestif))
+ (libraries graphql cohttp astring base64 ocplib-endian digestif))

--- a/graphql-cohttp/src/graphql_cohttp.ml
+++ b/graphql-cohttp/src/graphql_cohttp.ml
@@ -99,7 +99,7 @@ module Make
 
   let make_callback : (Cohttp.Request.t -> 'ctx) -> 'ctx Schema.schema -> 'conn callback = fun make_context schema _conn (req : Cohttp.Request.t) body ->
     let req_path = Cohttp.Request.uri req |> Uri.path in
-    let path_parts = Str.(split (regexp "/") req_path) in
+    let path_parts = Astring.String.cuts ~sep:"/" req_path in
     match req.meth, path_parts with
     | `GET,  ["graphql"] ->
       if Cohttp.Header.get req.Cohttp.Request.headers "Connection" = Some "Upgrade" && Cohttp.Header.get req.headers "Upgrade" = Some "websocket" then


### PR DESCRIPTION
Found this while experimenting with `irmin-mirage`

`graphql-cohttp` will need an update prior to the Irmin 2.0 release. I will add a note about this in the release issue (mirage/irmin#658).