### PR TITLE
Fix routing in graphql-cohttp

### DIFF
--- a/graphql-cohttp/src/graphql_cohttp.ml
+++ b/graphql-cohttp/src/graphql_cohttp.ml
@@ -99,7 +99,7 @@ module Make
 
   let make_callback : (Cohttp.Request.t -> 'ctx) -> 'ctx Schema.schema -> 'conn callback = fun make_context schema _conn (req : Cohttp.Request.t) body ->
     let req_path = Cohttp.Request.uri req |> Uri.path in
-    let path_parts = Astring.String.cuts ~sep:"/" req_path in
+    let path_parts = Astring.String.cuts ~empty:false ~sep:"/" req_path in
     match req.meth, path_parts with
     | `GET,  ["graphql"] ->
       if Cohttp.Header.get req.Cohttp.Request.headers "Connection" = Some "Upgrade" && Cohttp.Header.get req.headers "Upgrade" = Some "websocket" then


### PR DESCRIPTION
#146 inadvertently introduced a bug due to the different handling of empty parts when splitting strings:

```ocaml
(* Old implementation *)
Str.(split (regexp "/") "/graphql"
- : ["graphql"] : string list

(* New implementation *)
Astring.String.cuts ~sep:"/" "/graphql"
- : [""; "graphql"]

Astring.String.cuts ~sep:"/" "/graphql/"
- : [""; "graphql"; ""]
```

By adding `~empty:false`, the old behavior can be restored:

```ocaml
Astring.String.cuts ~empty:false ~sep:"/" "/graphql"
- : ["graphql"]

Astring.String.cuts ~empty:false ~sep:"/" "/graphql/"
- : ["graphql"]
```

This is preferable over changing the pattern matching (#149) due to handling of the trailing slashes.