### PR TITLE
graphql-cohttp: Improve parameter handling

### DIFF
--- a/graphql-cohttp.opam
+++ b/graphql-cohttp.opam
@@ -21,6 +21,9 @@ depends: [
   "base64" {>= "3.0.0"}
   "ocplib-endian" {>= "1.0"}
   "digestif" {>= "0.7.0"}
+  "alcotest" {with-test}
+  "cohttp-lwt-unix" {with-test}
+  "graphql-lwt" {with-test}
 ]
 
 synopsis: "Run GraphQL servers with `cohttp`"

--- a/graphql-cohttp/src/graphql_cohttp.ml
+++ b/graphql-cohttp/src/graphql_cohttp.ml
@@ -37,6 +37,103 @@ module type S = sig
     'conn callback
 end
 
+module Option = struct
+  let bind t ~f =
+    match t with
+    | None -> None
+    | Some x -> f x
+
+  let map t ~f =
+    bind t ~f:(fun x -> Some (f x))
+
+  let first_some t t' =
+    match t with
+    | None -> t'
+    | Some _ -> t
+end
+
+module Params = struct
+  type t = {
+    query : string option;
+    variables : (string * Yojson.Basic.t) list option;
+    operation_name : string option;
+  }
+
+  let empty =
+    {
+      query = None;
+      variables = None;
+      operation_name = None;
+    }
+
+  let of_uri_exn uri =
+    let variables =
+      Uri.get_query_param uri "variables"
+      |> Option.map ~f:Yojson.Basic.from_string
+      |> Option.map ~f:Yojson.Basic.Util.to_assoc
+    in
+    {
+      query = Uri.get_query_param uri "query";
+      variables;
+      operation_name = Uri.get_query_param uri "operationName";
+    }
+
+  let of_json_body_exn body =
+    if body = "" then
+      empty
+    else
+      let json = Yojson.Basic.from_string body in
+      {
+        query = Yojson.Basic.Util.(json |> member "query" |> to_option to_string);
+        variables = Yojson.Basic.Util.(json |> member "variables" |> to_option to_assoc);
+        operation_name = Yojson.Basic.Util.(json |> member "operationName" |> to_option to_string);
+      }
+
+  let of_graphql_body body =
+    {
+      query = Some body;
+      variables = None;
+      operation_name = None;
+    }
+
+  let merge t t' =
+    {
+      query = Option.first_some t.query t'.query;
+      variables = Option.first_some t.variables t'.variables;
+      operation_name = Option.first_some t.operation_name t'.operation_name;
+    }
+
+  let post_params_exn req body =
+    let headers = Cohttp.Request.headers req in
+    match Cohttp.Header.get headers "Content-Type" with
+    | Some "application/graphql" ->
+        of_graphql_body body
+    | Some "application/json" ->
+        of_json_body_exn body
+    | _ ->
+        empty
+
+  let of_req_exn req body =
+    let get_params = of_uri_exn (Cohttp.Request.uri req) in
+    let post_params = post_params_exn req body in
+    merge get_params post_params
+
+  let extract req body =
+    try
+      let params = of_req_exn req body in
+      match params.query with
+      | Some query ->
+          Ok (
+            query,
+            (params.variables :> (string * Graphql_parser.const_value) list option),
+            params.operation_name
+          )
+      | None ->
+          Error "Must provide query string"
+    with Yojson.Json_error msg ->
+      Error msg
+end
+
 module Make
   (Schema : Graphql_intf.Schema)
   (Io : Cohttp.S.IO with type 'a t = 'a Schema.Io.t)
@@ -68,46 +165,52 @@ module Make
     | Some body -> respond_string ~status:`OK ~body ()
     | None -> respond_string ~status:`Not_found ~body:"" ()
 
-  let json_err = function
-    | Ok _ as ok -> ok
-    | Error err -> Error (`String err)
-
   let execute_query ctx schema variables operation_name query =
-    let parser_result = json_err (Graphql_parser.parse query) in
-    Io.return parser_result >>= function
-    | Ok doc -> Schema.execute schema ctx ?variables ?operation_name doc
-    | Error _ as e -> Io.return e
+    match Graphql_parser.parse query with
+    | Ok doc ->
+        Schema.execute schema ctx ?variables ?operation_name doc
+    | Error e ->
+        Io.return (Error (`String e))
 
-  let execute_request schema ctx _req body =
-    Body.to_string body >>= fun body' ->
-    let json = Yojson.Basic.from_string body' in
-    let query = Yojson.Basic.(json |> Util.member "query" |> Util.to_string) in
-    let variables = Yojson.Basic.Util.(json |> member "variables" |> to_option to_assoc) in
-    let operation_name = Yojson.Basic.Util.(json |> member "operationName" |> to_option to_string) in
-    let result = execute_query ctx schema (variables :> (string * Graphql_parser.const_value) list option) operation_name query in
-    result >>= function
-    | Ok (`Response data) ->
-      let body = Yojson.Basic.to_string data in
-      respond_string ~status:`OK ~body ()
-    | Ok (`Stream stream) ->
-      Schema.Io.Stream.close stream;
-      let body = "Subscriptions are only supported via websocket transport" in
-      respond_string ~status:`Internal_server_error ~body ()
+  let execute_request schema ctx req body =
+    Body.to_string body >>= fun body_string ->
+    match Params.extract req body_string with
     | Error err ->
-      let body = Yojson.Basic.to_string err in
-      respond_string ~status:`Internal_server_error ~body ()
+        respond_string ~status:`Bad_request ~body:err ()
+    | Ok (query, variables, operation_name) ->
+        execute_query ctx schema variables operation_name query >>= function
+        | Ok (`Response data) ->
+            let body = Yojson.Basic.to_string data in
+            respond_string ~status:`OK ~body ()
+        | Ok (`Stream stream) ->
+            Schema.Io.Stream.close stream;
+            let body = "Subscriptions are only supported via websocket transport" in
+            respond_string ~status:`Bad_request ~body ()
+        | Error err ->
+            let body = Yojson.Basic.to_string err in
+            respond_string ~status:`Bad_request ~body ()
 
   let make_callback : (Cohttp.Request.t -> 'ctx) -> 'ctx Schema.schema -> 'conn callback = fun make_context schema _conn (req : Cohttp.Request.t) body ->
     let req_path = Cohttp.Request.uri req |> Uri.path in
     let path_parts = Astring.String.cuts ~empty:false ~sep:"/" req_path in
-    match req.meth, path_parts with
-    | `GET,  ["graphql"] ->
-      if Cohttp.Header.get req.Cohttp.Request.headers "Connection" = Some "Upgrade" && Cohttp.Header.get req.headers "Upgrade" = Some "websocket" then
+    let headers = Cohttp.Request.headers req in
+    let accept_html =
+      match Cohttp.Header.get headers "accept" with
+      | None -> false
+      | Some s -> List.mem "text/html" (String.split_on_char ',' s)
+    in
+    match req.meth, path_parts, accept_html with
+    | `GET, ["graphql"], true ->
+        static_file_response "index.html"
+    | `GET, ["graphql"], false ->
+      if Cohttp.Header.get headers "Connection" = Some "Upgrade" && Cohttp.Header.get headers "Upgrade" = Some "websocket" then
         let handle_conn =  Websocket_transport.handle (execute_query (make_context req) schema) in
         Io.return (Ws.upgrade_connection req handle_conn)
       else
-        static_file_response "index.html"
-    | `GET,  ["graphql"; path] -> static_file_response path
-    | `POST, ["graphql"]       -> execute_request schema (make_context req) req body
+        execute_request schema (make_context req) req body
+    | `GET, ["graphql"; path], _ ->
+        static_file_response path
+    | `POST, ["graphql"], _ ->
+        execute_request schema (make_context req) req body
     | _ -> respond_string ~status:`Not_found ~body:"" ()
 end

--- a/graphql-cohttp/test/dune
+++ b/graphql-cohttp/test/dune
@@ -1,0 +1,4 @@
+(tests
+  (package graphql-cohttp)
+  (names test)
+  (libraries cohttp-lwt-unix digestif.ocaml graphql-lwt graphql-cohttp alcotest))

--- a/graphql-cohttp/test/request_test.ml
+++ b/graphql-cohttp/test/request_test.ml
@@ -1,0 +1,147 @@
+open Lwt.Infix
+
+module Graphql_cohttp_lwt = Graphql_cohttp.Make (Graphql_lwt.Schema) (Cohttp_lwt_unix.IO) (Cohttp_lwt.Body)
+
+let schema = Graphql_lwt.Schema.(schema [
+  field "hello"
+    ~typ:(non_null string)
+    ~args:Arg.[
+      arg "name" ~typ:string
+    ]
+    ~resolve:(fun _ () -> function
+      | None -> "world"
+      | Some name -> name
+    )
+])
+
+let response_check = Alcotest.of_pp Cohttp.Response.pp_hum
+
+let check_body actual expected =
+  Cohttp_lwt.Body.to_string actual >|= fun body ->
+  Alcotest.(check string) "body" body expected
+
+let check_response_action ~rsp ~rsp_body actual =
+  match actual with
+  | `Expert _ ->
+      Alcotest.fail "Got expert, expected response"
+  | `Response (rsp', body') ->
+    Alcotest.check response_check "response" rsp' rsp;
+    check_body body' rsp_body
+
+let default_uri = Uri.of_string "/graphql"
+
+let json_content_type = Cohttp.Header.init_with "Content-Type" "application/json"
+let graphql_content_type = Cohttp.Header.init_with "Content-Type" "application/graphql"
+
+let default_response_body =
+  Yojson.Basic.to_string (`Assoc [
+    "data", `Assoc [
+      "hello", `String "world"
+    ]
+  ])
+
+let test_case ~req ~req_body ~rsp ~rsp_body =
+  Lwt_main.run begin
+    Graphql_cohttp_lwt.execute_request schema () req req_body >>=
+    check_response_action
+      ~rsp
+      ~rsp_body
+  end
+
+let suite = [
+  ("POST with empty body", `Quick, fun () ->
+    test_case
+      ~req:(Cohttp.Request.make ~meth:`POST default_uri)
+      ~req_body:Cohttp_lwt.Body.empty
+      ~rsp:(Cohttp.Response.make ~status:`Bad_request ())
+      ~rsp_body:"Must provide query string"
+  );
+  ("POST with json body", `Quick, fun () ->
+    let req_body = Cohttp_lwt.Body.of_string (Yojson.Basic.to_string (`Assoc [
+      "query", `String "{ hello }"
+    ])) in
+    test_case
+      ~req:(Cohttp.Request.make ~meth:`POST ~headers:json_content_type default_uri)
+      ~req_body
+      ~rsp:(Cohttp.Response.make ~status:`OK ())
+      ~rsp_body:default_response_body
+  );
+  ("POST with graphql body", `Quick, fun () ->
+    let req_body = Cohttp_lwt.Body.of_string "{ hello }" in
+    test_case
+      ~req:(Cohttp.Request.make ~meth:`POST ~headers:graphql_content_type default_uri)
+      ~req_body
+      ~rsp:(Cohttp.Response.make ~status:`OK ())
+      ~rsp_body:default_response_body
+  );
+  ("GET with empty query string", `Quick, fun () ->
+    test_case
+      ~req:(Cohttp.Request.make ~meth:`GET default_uri)
+      ~req_body:Cohttp_lwt.Body.empty
+      ~rsp:(Cohttp.Response.make ~status:`Bad_request ())
+      ~rsp_body:"Must provide query string"
+  );
+  ("GET with query", `Quick, fun () ->
+    let query = "{ hello }" in
+    let query = Some ["query", [query]] in
+    let uri = Uri.with_uri ~query default_uri in
+    test_case
+      ~req:(Cohttp.Request.make ~meth:`GET uri)
+      ~req_body:Cohttp_lwt.Body.empty
+      ~rsp:(Cohttp.Response.make ~status:`OK ())
+      ~rsp_body:default_response_body
+  );
+  ("operation name in JSON body", `Quick, fun () ->
+    let req_body = Cohttp_lwt.Body.of_string (Yojson.Basic.to_string (`Assoc [
+      "query", `String "query A { hello(name: \"world\") } query B { hello(name: \"fail\") }";
+      "operationName", `String "A"
+    ])) in
+    test_case
+      ~req:(Cohttp.Request.make ~meth:`POST ~headers:json_content_type default_uri)
+      ~req_body
+      ~rsp:(Cohttp.Response.make ~status:`OK ())
+      ~rsp_body:default_response_body
+  );
+  ("operation name in query string", `Quick, fun () ->
+    let req_body = Cohttp_lwt.Body.of_string (Yojson.Basic.to_string (`Assoc [
+      "query", `String "query A { hello(name: \"world\") } query B { hello(name: \"fail\") }"
+    ])) in
+    let query = Some ["operationName", ["A"]] in
+    let uri = Uri.with_uri ~query default_uri in
+    test_case
+      ~req:(Cohttp.Request.make ~meth:`POST ~headers:json_content_type uri)
+      ~req_body
+      ~rsp:(Cohttp.Response.make ~status:`OK ())
+      ~rsp_body:default_response_body
+  );
+  ("variables in JSON body", `Quick, fun () ->
+    let req_body = Cohttp_lwt.Body.of_string (Yojson.Basic.to_string (`Assoc [
+      "query", `String "query A($name: String!) { hello(name: $name) }";
+      "variables", `Assoc [
+        "name", `String "world"
+      ]
+    ])) in
+    test_case
+      ~req:(Cohttp.Request.make ~meth:`POST ~headers:json_content_type default_uri)
+      ~req_body
+      ~rsp:(Cohttp.Response.make ~status:`OK ())
+      ~rsp_body:default_response_body
+  );
+  ("variables in query string", `Quick, fun () ->
+    let req_body = Cohttp_lwt.Body.of_string (Yojson.Basic.to_string (`Assoc [
+      "query", `String "query A($name: String!) { hello(name: $name) }";
+    ])) in
+    let query =
+      Some [
+        "operationName", ["A"];
+        "variables", ["{\"name\":\"world\"}"];
+      ]
+    in
+    let uri = Uri.with_uri ~query default_uri in
+    test_case
+      ~req:(Cohttp.Request.make ~meth:`POST ~headers:json_content_type uri)
+      ~req_body
+      ~rsp:(Cohttp.Response.make ~status:`OK ())
+      ~rsp_body:default_response_body
+  );
+]

--- a/graphql-cohttp/test/test.ml
+++ b/graphql-cohttp/test/test.ml
@@ -1,0 +1,4 @@
+let () =
+  Alcotest.run "graphql-cohttp" [
+    "request", Request_test.suite;
+  ]


### PR DESCRIPTION
This PR updates the parameter handling (extracting the query, variables and operation name from the HTTP request and body) in an attempt to match [the description on graphql.org](https://graphql.org/learn/serving-over-http/) and [`express-graphql`](https://github.com/graphql/express-graphql).

In essence, the parameters are extracted from both the query string and the HTTP body, and the two are merged with the former taking precedence.

Further, GraphiQL is not served unless the request explicitly requests HTML to allow get requests.

Remaining tasks:

- [x] Add more test cases
- [x] More testing in GraphiQL