### PR TITLE
Use default variables in operations

### DIFF
--- a/graphql/test/variable_test.ml
+++ b/graphql/test/variable_test.ml
@@ -128,4 +128,21 @@ let suite : (string * [>`Quick] * (unit -> unit)) list = [
       ]
     ])
   );
+  ("default variable", `Quick, fun () ->
+    let query = "query has_defaults($x : Int! = 42) { int(x: $x) }" in
+    test_query [] query (`Assoc [
+      "data", `Assoc [
+        "int", `Int 42
+      ]
+    ])
+  );
+  ("variable overrides default variable", `Quick, fun () ->
+    let variables = ["x", `Int 43] in
+    let query = "query has_defaults($x : Int! = 42) { int(x: $x) }" in
+    test_query variables query (`Assoc [
+      "data", `Assoc [
+        "int", `Int 43
+      ]
+    ])
+  );
 ]


### PR DESCRIPTION
This diff fixes the bug where the following valid query was returning an error saying the variable `first` was missing:

```graphql
query example(
  $first: String! = 1
) {
  greeter(first:$first)
}
```