### PR TITLE
[RFC] Scoped context

### DIFF
--- a/graphql/src/graphql_intf.ml
+++ b/graphql/src/graphql_intf.ml
@@ -134,6 +134,14 @@ module type Schema = sig
                  resolve:('ctx resolve_info -> 'src -> 'b) ->
                  ('ctx, 'src) field
 
+  val io_field_with_set_context : ?doc:string ->
+                                  ?deprecated:deprecated ->
+                                  string ->
+                                  typ:('ctx, 'a) typ ->
+                                  args:(('a, string) result Io.t, 'b) Arg.arg_list ->
+                                  resolve:(('ctx -> unit) -> 'ctx resolve_info -> 'src -> 'b) ->
+                                  ('ctx, 'src) field
+
   val subscription_field : ?doc:string ->
                            ?deprecated:deprecated ->
                            string ->

--- a/graphql/src/graphql_schema.ml
+++ b/graphql/src/graphql_schema.ml
@@ -371,7 +371,8 @@ module Make (Io : IO) = struct
       deprecated : deprecated;
       typ        : ('ctx, 'out) typ;
       args       : ('a, 'args) Arg.arg_list;
-      resolve    : 'ctx resolve_info -> 'src -> 'args;
+      resolve    : [`Resolve of 'ctx resolve_info -> 'src -> 'args
+                   | `Resolve_with_set_child_context of ('ctx -> unit) -> 'ctx resolve_info -> 'src -> 'args];
       lift       : 'a -> ('out, string) result Io.t;
     } -> ('ctx, 'src) field
   and (_, _) typ =
@@ -474,10 +475,13 @@ module Make (Io : IO) = struct
     o
 
   let field ?doc ?(deprecated=NotDeprecated) name ~typ ~args ~resolve =
-    Field { name; doc; deprecated; typ; args; resolve; lift = Io.ok }
+    Field { name; doc; deprecated; typ; args; resolve = `Resolve resolve; lift = Io.ok }
 
   let io_field ?doc ?(deprecated=NotDeprecated) name ~typ ~args ~resolve =
-    Field { name; doc; deprecated; typ; args; resolve; lift = id }
+    Field { name; doc; deprecated; typ; args; resolve = `Resolve resolve; lift = id }
+
+  let io_field_with_set_context ?doc ?(deprecated=NotDeprecated) name ~typ ~args ~resolve =
+    Field { name; doc; deprecated; typ; args; resolve = `Resolve_with_set_child_context resolve; lift = id }
 
   let abstract_field ?doc ?(deprecated=NotDeprecated) name ~typ ~args =
     AbstractField (Field { lift = Io.ok; name; doc; deprecated; typ; args; resolve = Obj.magic () })
@@ -517,7 +521,7 @@ module Make (Io : IO) = struct
   let obj_of_subscription_obj {name; doc; fields} =
     let fields = List.map
       (fun (SubscriptionField {name; doc; deprecated; typ; args; resolve}) ->
-        Field { lift = Obj.magic (); name; doc; deprecated; typ; args; resolve = (fun ctx () -> resolve ctx) })
+        Field { lift = Obj.magic (); name; doc; deprecated; typ; args; resolve = `Resolve (fun ctx () -> resolve ctx) })
       fields
     in
     { name; doc; abstracts = ref []; fields = lazy fields }
@@ -730,7 +734,7 @@ module Introspection = struct
         typ = NonNullable string;
         args = Arg.[];
         lift = Io.ok;
-        resolve = fun _ (AnyEnumValue enum_value) -> enum_value.name;
+        resolve = `Resolve (fun _ (AnyEnumValue enum_value) -> enum_value.name);
       };
       Field {
         name = "description";
@@ -739,7 +743,7 @@ module Introspection = struct
         typ = string;
         args = Arg.[];
         lift = Io.ok;
-        resolve = fun _ (AnyEnumValue enum_value) -> enum_value.doc;
+        resolve = `Resolve (fun _ (AnyEnumValue enum_value) -> enum_value.doc);
       };
       Field {
         name = "isDeprecated";
@@ -748,7 +752,7 @@ module Introspection = struct
         typ = NonNullable bool;
         args = Arg.[];
         lift = Io.ok;
-        resolve = fun _ (AnyEnumValue enum_value) -> enum_value.deprecated <> NotDeprecated;
+        resolve = `Resolve (fun _ (AnyEnumValue enum_value) -> enum_value.deprecated <> NotDeprecated);
       };
       Field {
         name = "deprecationReason";
@@ -757,10 +761,10 @@ module Introspection = struct
         typ = string;
         args = Arg.[];
         lift = Io.ok;
-        resolve = fun _ (AnyEnumValue enum_value) ->
+        resolve = `Resolve (fun _ (AnyEnumValue enum_value) ->
           match enum_value.deprecated with
           | Deprecated reason -> reason
-          | NotDeprecated -> None
+          | NotDeprecated -> None)
       }
     ]
   }
@@ -777,9 +781,9 @@ module Introspection = struct
         typ = NonNullable string;
         args = Arg.[];
         lift = Io.ok;
-        resolve = fun _ (AnyArg arg) -> match arg with
+        resolve = `Resolve (fun _ (AnyArg arg) -> match arg with
           | Arg.DefaultArg a -> a.name
-          | Arg.Arg a -> a.name
+          | Arg.Arg a -> a.name)
       };
       Field {
         name = "description";
@@ -788,9 +792,9 @@ module Introspection = struct
         typ = string;
         args = Arg.[];
         lift = Io.ok;
-        resolve = fun _ (AnyArg arg) -> match arg with
+        resolve = `Resolve (fun _ (AnyArg arg) -> match arg with
           | Arg.DefaultArg a -> a.doc
-          | Arg.Arg a -> a.doc
+          | Arg.Arg a -> a.doc)
       };
       Field {
         name = "type";
@@ -799,9 +803,9 @@ module Introspection = struct
         typ = NonNullable __type;
         args = Arg.[];
         lift = Io.ok;
-        resolve = fun _ (AnyArg arg) -> match arg with
+        resolve = `Resolve (fun _ (AnyArg arg) -> match arg with
           | Arg.DefaultArg a -> AnyArgTyp a.typ
-          | Arg.Arg a -> AnyArgTyp a.typ
+          | Arg.Arg a -> AnyArgTyp a.typ)
       };
       Field {
         name = "defaultValue";
@@ -810,7 +814,7 @@ module Introspection = struct
         typ = string;
         args = Arg.[];
         lift = Io.ok;
-        resolve = fun _ (AnyArg _) -> None
+        resolve = `Resolve (fun _ (AnyArg _) -> None)
       }
     ]
   }
@@ -827,7 +831,7 @@ module Introspection = struct
         typ = NonNullable __type_kind;
         args = Arg.[];
         lift = Io.ok;
-        resolve = fun _ t -> match t with
+        resolve = `Resolve (fun _ t -> match t with
           | AnyTyp (Object _) -> `Object
           | AnyTyp (Abstract { kind = `Union; _ }) -> `Union
           | AnyTyp (Abstract { kind = `Interface _; _ }) -> `Interface
@@ -839,7 +843,7 @@ module Introspection = struct
           | AnyArgTyp (Arg.List _) -> `List
           | AnyArgTyp (Arg.Scalar _) -> `Scalar
           | AnyArgTyp (Arg.Enum _) -> `Enum
-          | AnyArgTyp (Arg.NonNullable _) -> `NonNull
+          | AnyArgTyp (Arg.NonNullable _) -> `NonNull)
       };
       Field {
         name = "name";
@@ -848,7 +852,7 @@ module Introspection = struct
         typ = string;
         args = Arg.[];
         lift = Io.ok;
-        resolve = fun _ t -> match t with
+        resolve = `Resolve (fun _ t -> match t with
           | AnyTyp (Object o) -> Some o.name
           | AnyTyp (Scalar s) -> Some s.name
           | AnyTyp (Enum e) -> Some e.name
@@ -856,7 +860,7 @@ module Introspection = struct
           | AnyArgTyp (Arg.Object o) -> Some o.name
           | AnyArgTyp (Arg.Scalar s) -> Some s.name
           | AnyArgTyp (Arg.Enum e) -> Some e.name
-          | _ -> None;
+          | _ -> None);
       };
       Field {
         name = "description";
@@ -865,7 +869,7 @@ module Introspection = struct
         typ = string;
         args = Arg.[];
         lift = Io.ok;
-        resolve = fun _ t -> match t with
+        resolve = `Resolve (fun _ t -> match t with
           | AnyTyp (Object o) -> o.doc
           | AnyTyp (Scalar s) -> s.doc
           | AnyTyp (Enum e) -> e.doc
@@ -873,7 +877,7 @@ module Introspection = struct
           | AnyArgTyp (Arg.Object o) -> o.doc
           | AnyArgTyp (Arg.Scalar s) -> s.doc
           | AnyArgTyp (Arg.Enum e) -> e.doc
-          | _ -> None
+          | _ -> None)
       };
       Field {
         name = "fields";
@@ -882,7 +886,7 @@ module Introspection = struct
         typ = List (NonNullable __field);
         args = Arg.[];
         lift = Io.ok;
-        resolve = fun _ t -> match t with
+        resolve = `Resolve (fun _ t -> match t with
           | AnyTyp (Object o) ->
               Some (List.map (fun f -> AnyField f) (Lazy.force o.fields))
           | AnyTyp (Abstract { kind = `Interface fields; _ }) ->
@@ -890,7 +894,7 @@ module Introspection = struct
           | AnyArgTyp (Arg.Object o) ->
               let arg_list = args_to_list o.fields in
               Some (List.map (fun (AnyArg f) -> AnyArgField f) arg_list)
-          | _ -> None
+          | _ -> None)
       };
       Field {
         name = "interfaces";
@@ -899,11 +903,11 @@ module Introspection = struct
         typ = List (NonNullable __type);
         args = Arg.[];
         lift = Io.ok;
-        resolve = fun _ t -> match t with
+        resolve = `Resolve (fun _ t -> match t with
           | AnyTyp (Object o) ->
               let interfaces = List.filter (function | { kind = `Interface _; _} -> true | _ -> false) !(o.abstracts) in
               Some (List.map (fun i -> AnyTyp (Abstract i)) interfaces)
-          | _ -> None
+          | _ -> None)
       };
       Field {
         name = "possibleTypes";
@@ -912,10 +916,10 @@ module Introspection = struct
         typ = List (NonNullable __type);
         args = Arg.[];
         lift = Io.ok;
-        resolve = fun _ t -> match t with
+        resolve = `Resolve (fun _ t -> match t with
           | AnyTyp (Abstract a) ->
               Some a.types
-          | _ -> None
+          | _ -> None)
       };
       Field {
         name = "ofType";
@@ -924,12 +928,12 @@ module Introspection = struct
         typ = __type;
         args = Arg.[];
         lift = Io.ok;
-        resolve = fun _ t -> match t with
+        resolve = `Resolve (fun _ t -> match t with
           | AnyTyp (NonNullable typ) -> Some (AnyTyp typ)
           | AnyTyp (List typ) -> Some (AnyTyp typ)
           | AnyArgTyp (Arg.NonNullable typ) -> Some (AnyArgTyp typ)
           | AnyArgTyp (Arg.List typ) -> Some (AnyArgTyp typ)
-          | _ -> None
+          | _ -> None)
       };
       Field {
         name = "inputFields";
@@ -938,10 +942,10 @@ module Introspection = struct
         typ = List (NonNullable __input_value);
         args = Arg.[];
         lift = Io.ok;
-        resolve = fun _ t -> match t with
+        resolve = `Resolve (fun _ t -> match t with
           | AnyArgTyp (Arg.Object o) ->
               Some (args_to_list o.fields)
-          | _ -> None
+          | _ -> None)
       };
       Field {
         name = "enumValues";
@@ -950,10 +954,10 @@ module Introspection = struct
         typ = List (NonNullable __enum_value);
         args = Arg.[];
         lift = Io.ok;
-        resolve = fun _ t -> match t with
+        resolve = `Resolve (fun _ t -> match t with
           | AnyTyp (Enum e) -> Some (List.map (fun x -> AnyEnumValue x) e.values)
           | AnyArgTyp (Arg.Enum e) -> Some (List.map (fun x -> AnyEnumValue x) e.values)
-          | _      -> None
+          | _      -> None)
       }
     ]
   }
@@ -970,10 +974,10 @@ module Introspection = struct
         typ = NonNullable string;
         args = Arg.[];
         lift = Io.ok;
-        resolve = fun _ f -> match f with
+        resolve = `Resolve (fun _ f -> match f with
           | AnyField (Field f) -> f.name
           | AnyArgField (Arg.Arg a) -> a.name
-          | AnyArgField (Arg.DefaultArg a) -> a.name
+          | AnyArgField (Arg.DefaultArg a) -> a.name)
       };
       Field {
         name = "description";
@@ -982,10 +986,10 @@ module Introspection = struct
         typ = string;
         args = Arg.[];
         lift = Io.ok;
-        resolve = fun _ f -> match f with
+        resolve = `Resolve (fun _ f -> match f with
           | AnyField (Field f) -> f.doc
           | AnyArgField (Arg.Arg a) -> a.doc
-          | AnyArgField (Arg.DefaultArg a) -> a.doc
+          | AnyArgField (Arg.DefaultArg a) -> a.doc)
       };
       Field {
         name = "args";
@@ -994,9 +998,9 @@ module Introspection = struct
         typ = NonNullable (List (NonNullable __input_value));
         args = Arg.[];
         lift = Io.ok;
-        resolve = fun _ f -> match f with
+        resolve = `Resolve (fun _ f -> match f with
           | AnyField (Field f) -> args_to_list f.args
-          | AnyArgField _ -> []
+          | AnyArgField _ -> [])
       };
       Field {
         name = "type";
@@ -1005,10 +1009,10 @@ module Introspection = struct
         typ = NonNullable __type;
         args = Arg.[];
         lift = Io.ok;
-        resolve = fun _ f -> match f with
+        resolve = `Resolve (fun _ f -> match f with
           | AnyField (Field f) -> AnyTyp f.typ
           | AnyArgField (Arg.Arg a) -> AnyArgTyp a.typ
-          | AnyArgField (Arg.DefaultArg a) -> AnyArgTyp a.typ
+          | AnyArgField (Arg.DefaultArg a) -> AnyArgTyp a.typ)
       };
       Field {
         name = "isDeprecated";
@@ -1017,9 +1021,9 @@ module Introspection = struct
         typ = NonNullable bool;
         args = Arg.[];
         lift = Io.ok;
-        resolve = fun _ f -> match f with
+        resolve = `Resolve (fun _ f -> match f with
           | AnyField (Field { deprecated = Deprecated _; _ }) -> true
-          | _ -> false
+          | _ -> false)
       };
       Field {
         name = "deprecationReason";
@@ -1028,9 +1032,9 @@ module Introspection = struct
         typ = string;
         args = Arg.[];
         lift = Io.ok;
-        resolve = fun _ f -> match f with
+        resolve = `Resolve (fun _ f -> match f with
           | AnyField (Field { deprecated = Deprecated reason; _ }) -> reason
-          | _ -> None
+          | _ -> None)
       }
     ]
   }
@@ -1102,7 +1106,7 @@ module Introspection = struct
         typ = NonNullable string;
         args = Arg.[];
         lift = Io.ok;
-        resolve = fun _ (Directive d) -> d.name
+        resolve = `Resolve (fun _ (Directive d) -> d.name)
       };
       Field {
         name = "description";
@@ -1111,7 +1115,7 @@ module Introspection = struct
         typ = string;
         args = Arg.[];
         lift = Io.ok;
-        resolve = fun _ (Directive d) -> d.doc
+        resolve = `Resolve (fun _ (Directive d) -> d.doc)
       };
       Field {
         name = "locations";
@@ -1120,7 +1124,7 @@ module Introspection = struct
         typ = NonNullable (List (NonNullable __directive_location));
         args = Arg.[];
         lift = Io.ok;
-        resolve = fun _ (Directive d) -> d.locations
+        resolve = `Resolve (fun _ (Directive d) -> d.locations)
       };
       Field {
         name = "args";
@@ -1129,7 +1133,7 @@ module Introspection = struct
         typ = NonNullable (List (NonNullable __input_value));
         args = Arg.[];
         lift = Io.ok;
-        resolve = fun _ (Directive d) -> args_to_list d.args
+        resolve = `Resolve (fun _ (Directive d) -> args_to_list d.args)
       }
     ]
   }
@@ -1146,7 +1150,7 @@ module Introspection = struct
         typ = NonNullable (List (NonNullable __type));
         args = Arg.[];
         lift = Io.ok;
-        resolve = fun _ s ->
+        resolve = `Resolve (fun _ s ->
           let types, _ = List.fold_left
             (fun memo op ->
               match op with
@@ -1155,7 +1159,7 @@ module Introspection = struct
             ([], StringSet.empty)
             [Some s.query; s.mutation; Option.map s.subscription ~f:obj_of_subscription_obj]
           in
-          types
+          types)
       };
       Field {
         name = "queryType";
@@ -1164,7 +1168,7 @@ module Introspection = struct
         typ = NonNullable __type;
         args = Arg.[];
         lift = Io.ok;
-        resolve = fun _ s -> AnyTyp (Object s.query)
+        resolve = `Resolve (fun _ s -> AnyTyp (Object s.query))
       };
       Field {
         name = "mutationType";
@@ -1173,7 +1177,7 @@ module Introspection = struct
         typ = __type;
         args = Arg.[];
         lift = Io.ok;
-        resolve = fun _ s -> Option.map s.mutation ~f:(fun mut -> AnyTyp (Object mut))
+        resolve = `Resolve (fun _ s -> Option.map s.mutation ~f:(fun mut -> AnyTyp (Object mut)))
       };
       Field {
         name = "subscriptionType";
@@ -1182,8 +1186,8 @@ module Introspection = struct
         typ = __type;
         args = Arg.[];
         lift = Io.ok;
-        resolve = fun _ s ->
-          Option.map s.subscription ~f:(fun subs -> AnyTyp (Object (obj_of_subscription_obj subs)))
+        resolve = `Resolve (fun _ s ->
+          Option.map s.subscription ~f:(fun subs -> AnyTyp (Object (obj_of_subscription_obj subs))))
       };
       Field {
         name = "directives";
@@ -1192,7 +1196,7 @@ module Introspection = struct
         typ = NonNullable (List (NonNullable __directive));
         args = Arg.[];
         lift = Io.ok;
-        resolve = fun _ _ -> []
+        resolve = `Resolve (fun _ _ -> [])
       };
       Field {
         name = "subscriptionType";
@@ -1201,7 +1205,7 @@ module Introspection = struct
         typ = __type;
         args = Arg.[];
         lift = Io.ok;
-        resolve = fun _ _ -> None
+        resolve = `Resolve (fun _ _ -> None)
       }
     ]
   }
@@ -1214,7 +1218,7 @@ module Introspection = struct
       typ = NonNullable __schema;
       args = Arg.[];
       lift = Io.ok;
-      resolve = fun _ _ -> s
+      resolve = `Resolve (fun _ _ -> s)
     } in
     let fields = lazy (schema_field::(Lazy.force s.query.fields)) in
     { s with query = { s.query with fields } }
@@ -1381,7 +1385,14 @@ end
         fragments = ctx.fragments;
         variables = ctx.variables;
       } in
-      let resolver = field.resolve resolve_info src in
+      let resolver = match field.resolve with
+      | `Resolve_with_set_child_context resolve ->
+         let ctx_ref = ref ctx.ctx in
+         let set_child_context = fun new_ctx -> ctx_ref := new_ctx in
+         resolve set_child_context resolve_info src
+      | `Resolve resolve ->
+         resolve resolve_info src
+      in
       match Arg.eval_arglist ctx.variables ~field_name:field.name field.args query_field.arguments resolver with
       | Ok unlifted_value ->
           let lifted_value =


### PR DESCRIPTION
We're working on a feature for OneGraph that allows users to query data across multiple accounts for the same provider in a single GraphQL query. For example, with our Gmail integration, you'd be able to query for both your work and your personal email in the same query. 

We'll be using an argument to allow the user to specify which account to query. It would look something like:

```
{
  google {
    personalMessages: gmail(accountId: "daniel@gmail.com") {
      messages {
        nodes {
          id
        }
      }
    }
    workMessages: gmail(accountId: "daniel@onegraph.com") {
      messages {
        nodes {
          id
        }
      }
    }
  }
}
```

We'd like to use scoped context to make sure the subqueries use the correct account.

## Background

Lacinia, the Clojure GraphQL library, implements scoped context: https://lacinia.readthedocs.io/en/latest/resolve/context.html

There's a short discussion in the graphql-js repo here: https://github.com/graphql/graphql-js/issues/354

## Implementation

This adds a new `io_field_with_set_context` field that behaves like an `io_field`, but passes a function to the resolve function that allows it to set the context for the child fields.

In usage, it looks something like:

```
  io_field_with_set_context "gmail"
    ~typ:gmailObj
    ~args:[arg "accountId" ~typ:(non_null string)]
    ~resolve:(fun setChildContext  ->
                fun { ctx }  ->
                  fun ()  ->
                    fun accountId  ->
                      setChildContext
                        {
                          ctx with
                          gmailAccountId = (Some (accountId))
                        };
                      Deferred.return ((Ok (()))

  io_field "messages" ~typ:gmailMessages
    ~resolve:(fun { ctx }  -> fun ()  -> fetchGmailMessages ctx.accountId)
```

I don't think this is the best way to implement the feature, but I ran into troubles getting the types to work with other approaches. I'd love to get some feedback on how you'd think about implementing other approaches.

Other ideas for implementation:

1. Change the return type of `io_field_with_set_context` to a tuple or record with context and the normal result. This is what I initially attempted and where I got stuck.
2. Change the return type of field/io_field to be an internal type with helper functions to return either values or values with context. `io_field_with_set_context` above would be a normal io_field with `Resolve.with_context((),  {ctx with gmailAccountId = (Some (accountId))})`.