### PR TITLE
graphql_parser: add upper bound for fmt

### DIFF
--- a/graphql_parser.opam
+++ b/graphql_parser.opam
@@ -16,7 +16,7 @@ depends: [
   "dune" {build}
   "menhir" {build}
   "alcotest" {with-test & >= "0.8.1"}
-  "fmt"
+  "fmt" {< "0.8.7"}
   "re" {>= "1.5.0"}
 ]
 


### PR DESCRIPTION
Travis is currently failing because of `fmt 0.8.7`. Related to https://github.com/dbuenzli/fmt/commit/7e2b942ceb99a9406063c7540d9d8b582e936b85