### PR TITLE
Custom errors

### DIFF
--- a/graphql-async/src/graphql_async.ml
+++ b/graphql-async/src/graphql_async.ml
@@ -15,6 +15,6 @@ module Schema = Graphql_schema.Make (struct
   end
 end) (struct
   type t = string
-  let message_of_error t = t
-  let extensions_of_error _t = []
+  let message_of_field_error t = t
+  let extensions_of_field_error _t = None
 end)

--- a/graphql-async/src/graphql_async.ml
+++ b/graphql-async/src/graphql_async.ml
@@ -13,4 +13,8 @@ module Schema = Graphql_schema.Make (struct
 
     let close = Async_kernel.Pipe.close_read
   end
+end) (struct
+  type t = string
+  let message_of_error t = t
+  let extensions_of_error _t = []
 end)

--- a/graphql-async/src/graphql_async.mli
+++ b/graphql-async/src/graphql_async.mli
@@ -2,5 +2,5 @@
 module Schema : sig
   include Graphql_intf.Schema with type 'a Io.t = 'a Async_kernel.Deferred.t
                               and type 'a Io.Stream.t = 'a Async_kernel.Pipe.Reader.t
-                              and type err = string
+                              and type field_error = string
 end

--- a/graphql-async/src/graphql_async.mli
+++ b/graphql-async/src/graphql_async.mli
@@ -2,4 +2,5 @@
 module Schema : sig
   include Graphql_intf.Schema with type 'a Io.t = 'a Async_kernel.Deferred.t
                               and type 'a Io.Stream.t = 'a Async_kernel.Pipe.Reader.t
+                              and type err = string
 end

--- a/graphql-lwt/src/graphql_lwt.ml
+++ b/graphql-lwt/src/graphql_lwt.ml
@@ -10,6 +10,6 @@ module Schema = Graphql_schema.Make (struct
   end
 end) (struct
   type t = string
-  let message_of_error t = t
-  let extensions_of_error _t = []
+  let message_of_field_error t = t
+  let extensions_of_field_error _t = None
 end)

--- a/graphql-lwt/src/graphql_lwt.ml
+++ b/graphql-lwt/src/graphql_lwt.ml
@@ -8,4 +8,8 @@ module Schema = Graphql_schema.Make (struct
     let iter (t, _close) f = Lwt_stream.iter_s f t
     let close (_, close) = close ()
   end
+end) (struct
+  type t = string
+  let message_of_error t = t
+  let extensions_of_error _t = []
 end)

--- a/graphql-lwt/src/graphql_lwt.mli
+++ b/graphql-lwt/src/graphql_lwt.mli
@@ -2,4 +2,5 @@
 module Schema : sig
   include Graphql_intf.Schema with type 'a Io.t = 'a Lwt.t
                                and type 'a Io.Stream.t = 'a Lwt_stream.t * (unit -> unit)
+                               and type err = string
 end

--- a/graphql-lwt/src/graphql_lwt.mli
+++ b/graphql-lwt/src/graphql_lwt.mli
@@ -2,5 +2,5 @@
 module Schema : sig
   include Graphql_intf.Schema with type 'a Io.t = 'a Lwt.t
                                and type 'a Io.Stream.t = 'a Lwt_stream.t * (unit -> unit)
-                               and type err = string
+                               and type field_error = string
 end

--- a/graphql/src/graphql.ml
+++ b/graphql/src/graphql.ml
@@ -11,4 +11,8 @@ module Schema = Graphql_schema.Make (struct
     let iter t f = Seq.iter f t
     let close _t = ()
   end
+end) (struct
+  type t = string
+  let message_of_error t = t
+  let extensions_of_error _t = []
 end)

--- a/graphql/src/graphql.ml
+++ b/graphql/src/graphql.ml
@@ -13,6 +13,6 @@ module Schema = Graphql_schema.Make (struct
   end
 end) (struct
   type t = string
-  let message_of_error t = t
-  let extensions_of_error _t = []
+  let message_of_field_error t = t
+  let extensions_of_field_error _t = None
 end)

--- a/graphql/src/graphql.mli
+++ b/graphql/src/graphql.mli
@@ -2,4 +2,5 @@
 module Schema : sig
   include Graphql_intf.Schema with type 'a Io.t = 'a
                                and type 'a Io.Stream.t = 'a Seq.t
+                               and type err = string
 end

--- a/graphql/src/graphql.mli
+++ b/graphql/src/graphql.mli
@@ -2,5 +2,5 @@
 module Schema : sig
   include Graphql_intf.Schema with type 'a Io.t = 'a
                                and type 'a Io.Stream.t = 'a Seq.t
-                               and type err = string
+                               and type field_error = string
 end

--- a/graphql/src/graphql_intf.ml
+++ b/graphql/src/graphql_intf.ml
@@ -15,6 +15,13 @@ module type IO = sig
   end with type 'a io := 'a t
 end
 
+(* Err signature *)
+module type Err = sig
+  type t
+  val message_of_error : t -> string
+  val extensions_of_error : t -> (string * Yojson.Basic.json [@warning "-3"]) list
+end
+
 (** GraphQL schema signature *)
 module type Schema = sig
   module Io : IO
@@ -26,6 +33,8 @@ module type Schema = sig
     val find_exn : key -> 'a t -> 'a
     val find : key -> 'a t -> 'a option
   end
+
+  type err
 
   (** {3 Base types } *)
 
@@ -130,7 +139,7 @@ module type Schema = sig
                  ?deprecated:deprecated ->
                  string ->
                  typ:('ctx, 'a) typ ->
-                 args:(('a, string) result Io.t, 'b) Arg.arg_list ->
+                 args:(('a, err) result Io.t, 'b) Arg.arg_list ->
                  resolve:('ctx resolve_info -> 'src -> 'b) ->
                  ('ctx, 'src) field
 
@@ -138,7 +147,7 @@ module type Schema = sig
                            ?deprecated:deprecated ->
                            string ->
                            typ:('ctx, 'out) typ ->
-                           args:(('out Io.Stream.t, string) result Io.t, 'args) Arg.arg_list ->
+                           args:(('out Io.Stream.t, err) result Io.t, 'args) Arg.arg_list ->
                            resolve:('ctx resolve_info -> 'args) ->
                            'ctx subscription_field
 

--- a/graphql/src/graphql_intf.ml
+++ b/graphql/src/graphql_intf.ml
@@ -15,11 +15,11 @@ module type IO = sig
   end with type 'a io := 'a t
 end
 
-(* Err signature *)
-module type Err = sig
+(* Field_error signature *)
+module type Field_error = sig
   type t
-  val message_of_error : t -> string
-  val extensions_of_error : t -> (string * Yojson.Basic.json [@warning "-3"]) list
+  val message_of_field_error : t -> string
+  val extensions_of_field_error : t -> (string * Yojson.Basic.json [@warning "-3"]) list option
 end
 
 (** GraphQL schema signature *)
@@ -34,7 +34,7 @@ module type Schema = sig
     val find : key -> 'a t -> 'a option
   end
 
-  type err
+  type field_error
 
   (** {3 Base types } *)
 
@@ -139,7 +139,7 @@ module type Schema = sig
                  ?deprecated:deprecated ->
                  string ->
                  typ:('ctx, 'a) typ ->
-                 args:(('a, err) result Io.t, 'b) Arg.arg_list ->
+                 args:(('a, field_error) result Io.t, 'b) Arg.arg_list ->
                  resolve:('ctx resolve_info -> 'src -> 'b) ->
                  ('ctx, 'src) field
 
@@ -147,7 +147,7 @@ module type Schema = sig
                            ?deprecated:deprecated ->
                            string ->
                            typ:('ctx, 'out) typ ->
-                           args:(('out Io.Stream.t, err) result Io.t, 'args) Arg.arg_list ->
+                           args:(('out Io.Stream.t, field_error) result Io.t, 'args) Arg.arg_list ->
                            resolve:('ctx resolve_info -> 'args) ->
                            'ctx subscription_field
 

--- a/graphql/src/graphql_schema.mli
+++ b/graphql/src/graphql_schema.mli
@@ -1,3 +1,3 @@
 (* GraphQL schema functor *)
-module Make (Io : Graphql_intf.IO) :
-  Graphql_intf.Schema with module Io = Io
+module Make (Io : Graphql_intf.IO) (Err : Graphql_intf.Err) :
+  Graphql_intf.Schema with module Io = Io and type err = Err.t

--- a/graphql/src/graphql_schema.mli
+++ b/graphql/src/graphql_schema.mli
@@ -1,3 +1,3 @@
 (* GraphQL schema functor *)
-module Make (Io : Graphql_intf.IO) (Err : Graphql_intf.Err) :
-  Graphql_intf.Schema with module Io = Io and type err = Err.t
+module Make (Io : Graphql_intf.IO) (Field_error : Graphql_intf.Field_error) :
+  Graphql_intf.Schema with module Io = Io and type field_error = Field_error.t

--- a/graphql/test/custom_error_test.ml
+++ b/graphql/test/custom_error_test.ml
@@ -1,13 +1,13 @@
 open Test_common
 
-module Err = struct
+module Field_error = struct
   type t = | String of string | Extension of string * string
-  let message_of_error t = match t with
+  let message_of_field_error t = match t with
     | String s -> s
     | Extension _ -> ""
-  let extensions_of_error t = match t with
-    | String _ -> []
-    | Extension (k, v) -> [(k, `String v)]
+  let extensions_of_field_error t = match t with
+    | String _ -> None
+    | Extension (k, v) -> Some [(k, `String v)]
 end
 
 module CustomErrorsSchema = Graphql_schema.Make (struct
@@ -23,7 +23,7 @@ module CustomErrorsSchema = Graphql_schema.Make (struct
     let iter t f = Seq.iter f t
     let close _t = ()
   end
-end) (Err)
+end) (Field_error)
 
 let test_query schema ctx ?variables ?operation_name query expected =
   match Graphql_parser.parse query with
@@ -45,11 +45,11 @@ let schema = CustomErrorsSchema.(schema [
   io_field "string_error"
     ~typ:int
     ~args:Arg.[]
-    ~resolve:(fun _ () -> Error (Err.String "error string"));
+    ~resolve:(fun _ () -> Error (Field_error.String "error string"));
   io_field "extensions_error"
     ~typ:int
     ~args:Arg.[]
-    ~resolve:(fun _ () -> Error (Err.Extension ("custom", "json")))
+    ~resolve:(fun _ () -> Error (Field_error.Extension ("custom", "json")))
 ])
 
 let suite = [

--- a/graphql/test/custom_error_test.ml
+++ b/graphql/test/custom_error_test.ml
@@ -1,0 +1,87 @@
+open Test_common
+
+module Err = struct
+  type t = | String of string | Extension of string * string
+  let message_of_error t = match t with
+    | String s -> s
+    | Extension _ -> ""
+  let extensions_of_error t = match t with
+    | String _ -> []
+    | Extension (k, v) -> [(k, `String v)]
+end
+
+module CustomErrorsSchema = Graphql_schema.Make (struct
+  type +'a t = 'a
+
+  let bind t f = f t
+  let return t = t
+
+  module Stream = struct
+    type 'a t = 'a Seq.t
+
+    let map t f = Seq.map f t
+    let iter t f = Seq.iter f t
+    let close _t = ()
+  end
+end) (Err)
+
+let test_query schema ctx ?variables ?operation_name query expected =
+  match Graphql_parser.parse query with
+  | Error err -> failwith err
+  | Ok doc ->
+      let result = match CustomErrorsSchema.execute schema ctx ?variables ?operation_name doc with
+      | Ok (`Response data) -> data
+      | Ok (`Stream stream) ->
+          begin try match stream () with
+          | Seq.Cons (Ok _, _) -> `List (list_of_seq stream)
+          | Seq.Cons (Error err, _) -> err
+          | Seq.Nil -> `Null
+          with _ -> `String "caught stream exn" end
+      | Error err -> err
+      in
+      Alcotest.check yojson "invalid execution result" expected result
+
+let schema = CustomErrorsSchema.(schema [
+  io_field "string_error"
+    ~typ:int
+    ~args:Arg.[]
+    ~resolve:(fun _ () -> Error (Err.String "error string"));
+  io_field "extensions_error"
+    ~typ:int
+    ~args:Arg.[]
+    ~resolve:(fun _ () -> Error (Err.Extension ("custom", "json")))
+])
+
+let suite = [
+  ("message without extensions", `Quick, fun () ->
+    let query = "{ string_error }" in
+    test_query schema () query (`Assoc [
+      "errors", `List [
+        `Assoc [
+          "message", `String "error string";
+          "path", `List [`String "string_error"]
+        ]
+      ];
+      "data", `Assoc [
+        "string_error", `Null
+      ]
+    ])
+  );
+  ("message with extensions", `Quick, fun () ->
+    let query = "{ extensions_error }" in
+    test_query schema () query (`Assoc [
+      "errors", `List [
+        `Assoc [
+          "message", `String "";
+          "path", `List [`String "extensions_error"];
+          "extensions", `Assoc [
+            "custom", `String "json"
+          ]
+        ]
+      ];
+      "data", `Assoc [
+        "extensions_error", `Null
+      ]
+    ])
+  );
+]

--- a/graphql/test/dune
+++ b/graphql/test/dune
@@ -10,6 +10,7 @@
   argument_test
   introspection_test
   error_test
+  custom_error_test
   abstract_test
   directives_test)
  (libraries graphql alcotest)

--- a/graphql/test/test.ml
+++ b/graphql/test/test.ml
@@ -5,6 +5,7 @@ let () =
     "variables", Variable_test.suite;
     "introspection", Introspection_test.suite;
     "errors", Error_test.suite;
+    "custom_errors", Custom_error_test.suite;
     "abstract", Abstract_test.suite;
     "directives", Directives_test.suite;
   ]


### PR DESCRIPTION
Adds support for building a schema with a custom error type.

This allows users of ocaml-graphql-server to add extra error information in the extensions field of the error response. 

OneGraph is using this in production to provide more context in the errors that we display to the user. For example, we provide hints if the user is not logged in (try https://www.onegraph.com/graphiql?shortenedId=41WMZX) and nicely format json errors from upstream APIs (try https://www.onegraph.com/graphiql?shortenedId=VJSMV7).

There is a test with an example schema module:

```
module Err = struct
  type t = | String of string | Extension of string * string
  let message_of_error t = match t with
    | String s -> s
    | Extension _ -> ""
  let extensions_of_error t = match t with
    | String _ -> []
    | Extension (k, v) -> [(k, `String v)]
end

module CustomErrorsSchema = Graphql_schema.Make (struct
  type +'a t = 'a

  let bind t f = f t
  let return t = t

  module Stream = struct
    type 'a t = 'a Seq.t

    let map t f = Seq.map f t
    let iter t f = Seq.iter f t
    let close _t = ()
  end
end) (Err)
```

Example resolver:
```
let schema = CustomErrorsSchema.(schema [
  io_field "string_error"
    ~typ:int
    ~args:Arg.[]
    ~resolve:(fun _ () -> Error (Err.String "error string"));
  io_field "extensions_error"
    ~typ:int
    ~args:Arg.[]
    ~resolve:(fun _ () -> Error (Err.Extension ("custom", "json")))
])
```