### PR TITLE
Merge fields defined in fragments

### DIFF
--- a/graphql/test/schema_test.ml
+++ b/graphql/test/schema_test.ml
@@ -160,7 +160,7 @@ let suite = [
         }
         ...F1
       }
-      fragment F1 on Query {
+      fragment F1 on query {
         users {
           name
         }

--- a/graphql/test/schema_test.ml
+++ b/graphql/test/schema_test.ml
@@ -152,6 +152,39 @@ let suite = [
       ]
     ])
   );
+  ("fragments combine nested fields", `Quick, fun () ->
+    let query = "
+      query Q {
+        users {
+          role
+        }
+        ...F1
+      }
+      fragment F1 on Query {
+        users {
+          name
+        }
+      }
+    " in
+    test_query query (`Assoc [
+      "data", `Assoc [
+        "users", `List [
+          `Assoc [
+            "role", `String "admin";
+            "name", `String "Alice";
+          ];
+          `Assoc [
+            "role", `String "user";
+            "name", `String "Bob";
+          ];
+          `Assoc [
+            "role", `String "user";
+            "name", `String "Charlie";
+          ]
+        ]
+      ]
+    ])
+  );
   ("introspection query should be accepted", `Quick, fun () ->
     let query = "
       query IntrospectionQuery {


### PR DESCRIPTION
Fixes #167.

Merges selection sets in `collect_fields`.

Uses a StringMap to facilitate the merging, then walks the list of fields to ensure we haven't changed the ordering.

