### PR TITLE
Fix for fmt >= 0.8.7

### DIFF
--- a/graphql_parser.opam
+++ b/graphql_parser.opam
@@ -16,7 +16,7 @@ depends: [
   "dune" {build}
   "menhir" {build}
   "alcotest" {with-test & >= "0.8.1"}
-  "fmt" {< "0.8.7"}
+  "fmt"
   "re" {>= "1.5.0"}
 ]
 

--- a/graphql_parser/src/ast.ml
+++ b/graphql_parser/src/ast.ml
@@ -96,8 +96,8 @@ type document =
   definition list
 
 module Pp = struct
-  let comma = Fmt.(const string ",")
-  let colon = Fmt.(const string ":")
+  let comma : unit Fmt.t = Fmt.(const string ",")
+  let colon : unit Fmt.t = Fmt.(const string ":")
 
   let quote_string s =
     let open Re in


### PR DESCRIPTION
This will be unnecessary if #140 is merged. But until then, the constraint on `fmt` is quite annoying and can be easily fixed by adding explicit type annotations.