### PR TITLE
Add logging to the example

### DIFF
--- a/examples/server.ml
+++ b/examples/server.ml
@@ -109,18 +109,17 @@ let schema = Schema.(schema [
 module Graphql_cohttp_lwt = Graphql_cohttp.Make (Graphql_lwt.Schema) (Cohttp_lwt_unix.IO) (Cohttp_lwt.Body)
 
 let () =
+  let open Printf in
   let on_exn = function
     | Unix.Unix_error (error, func, arg) ->
-      Logs.warn (fun m ->
-        m  "Client connection error %s: %s(%S)"
+      printf "Client connection error %s: %s(%S)"
           (Unix.error_message error) func arg
-      )
-    | exn -> Logs.err (fun m -> m "Unhandled exception: %a" Fmt.exn exn)
+    | exn -> printf "Unhandled exception: %s\n%!" (Printexc.to_string exn)
   in
   let callback = Graphql_cohttp_lwt.make_callback (fun _req -> ()) schema in
   let server = Cohttp_lwt_unix.Server.make_response_action ~callback () in
   let port = 8080 in
   let mode = `TCP (`Port port) in
-  Printf.printf "listening on http://localhost:%d/graphql\n%!" port ;
+  printf "listening on http://localhost:%d/graphql\n%!" port ;
   Cohttp_lwt_unix.Server.create ~on_exn ~mode server
   |> Lwt_main.run

--- a/examples/server.ml
+++ b/examples/server.ml
@@ -120,6 +120,6 @@ let () =
   let server = Cohttp_lwt_unix.Server.make_response_action ~callback () in
   let port = 8080 in
   let mode = `TCP (`Port port) in
-  printf "listening on http://localhost:%d/graphql\n%!" port ;
+  printf "listening on http://localhost:%d/graphql\n%!" port;
   Cohttp_lwt_unix.Server.create ~on_exn ~mode server
   |> Lwt_main.run

--- a/examples/server.ml
+++ b/examples/server.ml
@@ -119,6 +119,8 @@ let () =
   in
   let callback = Graphql_cohttp_lwt.make_callback (fun _req -> ()) schema in
   let server = Cohttp_lwt_unix.Server.make_response_action ~callback () in
-  let mode = `TCP (`Port 8080) in
+  let port = 8080 in
+  let mode = `TCP (`Port port) in
+  Printf.printf "listening on http://localhost:%d/graphql\n%!" port ;
   Cohttp_lwt_unix.Server.create ~on_exn ~mode server
   |> Lwt_main.run


### PR DESCRIPTION
This PR adds logging to `./examples/server.exe` and outputs a where the server URL:

```
listening on http://localhost:8080/graphql
```

Hoping this makes it more intuitive for onboarding newcomers.