### PR TITLE
Add ocamlformat

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,0 +1,1 @@
+profile = conventional

--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,3 @@
 (lang dune 1.1)
 (using menhir 2.0)
+(using fmt 1.2)

--- a/graphql/test/schema_test.ml
+++ b/graphql/test/schema_test.ml
@@ -127,7 +127,7 @@ let suite = [
     ])
   );
   ("fragments cannot form cycles", `Quick, fun () ->
-    let query = "
+    let query = {|
       fragment F1 on Foo {
         ... on Bar {
           baz {
@@ -143,7 +143,7 @@ let suite = [
       {
         ... F1
       }
-    " in
+    |} in
     test_query query (`Assoc [
       "errors", `List [
         `Assoc [
@@ -153,7 +153,7 @@ let suite = [
     ])
   );
   ("fragments combine nested fields", `Quick, fun () ->
-    let query = "
+    let query = {|
       query Q {
         users {
           role
@@ -165,7 +165,7 @@ let suite = [
           name
         }
       }
-    " in
+    |} in
     test_query query (`Assoc [
       "data", `Assoc [
         "users", `List [
@@ -186,7 +186,7 @@ let suite = [
     ])
   );
   ("introspection query should be accepted", `Quick, fun () ->
-    let query = "
+    let query = {|
       query IntrospectionQuery {
         __schema {
           queryType { name }
@@ -278,7 +278,7 @@ let suite = [
           }
         }
       }
-    " in
+    |} in
     match Graphql_parser.parse query with
     | Error err -> failwith err
     | Ok doc ->

--- a/graphql_parser/test/parser_test.ml
+++ b/graphql_parser/test/parser_test.ml
@@ -13,8 +13,8 @@ let test_query query =
       Alcotest.failf "Failed to parse %s: %s" query err
 
 let test_introspection_query () =
-  test_query
-    "query IntrospectionQuery {
+  test_query {|
+    query IntrospectionQuery {
       __schema {
         queryType { name }
         mutationType { name }
@@ -90,11 +90,12 @@ let test_introspection_query () =
           }
         }
       }
-    }"
+    }
+  |}
 
 let test_kitchen_sink () =
-  test_query
-    "query queryName($foo: ComplexType, $site: Site = MOBILE) {
+  test_query {|
+    query queryName($foo: ComplexType, $site: Site = MOBILE) {
       whoever123is: node(id: [123, 456]) {
         id ,
         ... on User @defer {
@@ -137,17 +138,18 @@ let test_kitchen_sink () =
     }
 
     fragment frag on Friend {
-      foo(size: $size, bar: $b, obj: {key: \"value\"})
+      foo(size: $size, bar: $b, obj: {key: "value"})
     }
 
     {
       unnamed(truthy: true, falsey: false, nullish: null),
       query
-    }"
+    }
+  |}
 
 let test_variables () =
-  test_query
-    "query Named($a: String, $b: Float) {
+  test_query {|
+    query Named($a: String, $b: Float) {
       x
     }
 
@@ -157,22 +159,24 @@ let test_variables () =
 
     query NonNull($a: ID!, $b: [Foo]!, $c: [Foo!], $d: [Foo!]!) {
       x
-    }"
+    }
+  |}
 
 let test_default_values () =
-  test_query
-    "query DefaultValues(
+  test_query {|
+    query DefaultValues(
         $a: Int = 1,
-        $b: [String] = [\"a\"],
+        $b: [String] = ["a"],
         $c: Obj = {x: {y: true}, z: RED},
         $d: [Obj]! = [{x: {y: null}, z: BLUE}]
       ) {
       x
-    }"
+    }
+  |}
 
 let test_keywords () =
-  test_query
-    "query Keywords(
+  test_query {|
+    query Keywords(
       $fragment: Int,
       $false: Int,
       $mutation: Int,
@@ -218,11 +222,12 @@ let test_keywords () =
 
     fragment true on Foo {
       a
-    }"
+    }
+  |}
 
 let test_escaped_string () =
   test_query {|
-    {	
+    {
       escaped_quote(x: "\"")
       backslash(x: "\\")
       slash(x: "/")


### PR DESCRIPTION
This PR adds `ocamlformat`, using the `conventional` format.

It only brings the minimum changes necessary to format the project:

```sh
$ dune build @fmt --auto-promote
```

After that it is expected that @andreas would commit those changes as the main author. After that we would enforce the formatting rules on travisCI (as per [@anmonteiro's suggestion](https://github.com/andreas/ocaml-graphql-server/issues/173#issuecomment-536330693)) to ensure that any new code merged follows the formatting rules.