### PR TITLE
Fix 2 subscriptions bugs

### DIFF
--- a/graphql/test/introspection_test.ml
+++ b/graphql/test/introspection_test.ml
@@ -146,4 +146,46 @@ let suite = [
       ]
     ])
   );
+  ("__typename", `Quick, fun () ->
+    let schema = Graphql.Schema.(schema
+      ~query_name:"MyQuery" []
+      ~mutations:[]
+      ~mutation_name:"MyMutation"
+      ~subscriptions:[]
+      ~subscription_name:"MySubscription"
+    ) in
+    test_query schema
+      {|
+        query {
+          __typename
+        }
+      |}
+      (`Assoc [
+        "data", `Assoc [
+          "__typename", `String "MyQuery"
+        ]
+      ]);
+    test_query schema
+      {|
+        mutation {
+          __typename
+        }
+      |}
+      (`Assoc [
+        "data", `Assoc [
+          "__typename", `String "MyMutation"
+        ]
+      ]);
+    test_query schema
+      {|
+        subscription {
+          __typename
+        }
+      |}
+      (`Assoc [
+        "data", `Assoc [
+          "__typename", `String "MySubscription"
+        ]
+      ])
+  )
 ]

--- a/graphql/test/schema_test.ml
+++ b/graphql/test/schema_test.ml
@@ -336,5 +336,15 @@ let suite = [
         ]
       ]
     ])
+  );
+  ("subscription field that doesn't exist", `Quick, fun () ->
+    let query = "subscription { dont_exist { id name } }" in
+    test_query query (`Assoc [
+      "errors", `List [
+        `Assoc [
+          "message", `String "Field 'dont_exist' is not defined on type 'subscription'"
+        ]
+      ]
+    ])
   )
 ]


### PR DESCRIPTION
1. Instrospection on `__typename`
2. No error was returned if requesting a subscription field that didn't
exist