### PR TITLE
Handle missing variables as null

### DIFF
--- a/graphql/test/variable_test.ml
+++ b/graphql/test/variable_test.ml
@@ -97,6 +97,35 @@ let suite : (string * [> `Quick ] * (unit -> unit)) list =
                   ] );
               ("data", `Null);
             ]) );
+    ( "missing required variable",
+      `Quick,
+      fun () ->
+        let variables = [] in
+        let query = "{ input_obj(x: $x) }" in
+        test_query variables query
+          (`Assoc
+            [
+              ( "errors",
+                `List
+                  [
+                    `Assoc
+                      [
+                        ( "message",
+                          `String
+                            "Argument `x` of type `person!` expected on field \
+                             `input_obj`, found null." );
+                      ];
+                  ] );
+              ("data", `Null);
+            ]) );
+    ( "missing nullable variable",
+      `Quick,
+      fun () ->
+        let variables = [] in
+        let query = "{ string(x: $x) }" in
+        test_query variables query
+        (`Assoc ["data", `Assoc ["string", `Null]])
+    );
     ( "variable coercion: single value to list",
       `Quick,
       fun () ->


### PR DESCRIPTION
As raised in #181, missing variables are currently handled incorrectly: the request should not be rejected with an error all together, rather the variable should be handled as null. This PR updates the variable handling logic, such that this is the case.

Note that the error message is not great when a missing variable is used for a required argument. This will be revisited later.

closes #181 