### PR TITLE
Show defaultValue in introspection query

### DIFF
--- a/examples/server.ml
+++ b/examples/server.ml
@@ -86,7 +86,7 @@ let schema =
                           ~coerce:(fun greeting name -> (greeting, name))
                           ~fields:
                             [
-                              arg' "greeting" ~typ:string ~default:"hello";
+                              arg' "greeting" ~typ:string ~default:(`String "hello");
                               arg "name" ~typ:(non_null string);
                             ]));
               ]
@@ -96,7 +96,7 @@ let schema =
       ~subscriptions:
         [
           subscription_field "subscribe_to_user" ~typ:(non_null user)
-            ~args:Arg.[ arg' "intarg" ~typ:int ~default:42 ]
+            ~args:Arg.[ arg' "intarg" ~typ:int ~default:(`Int 42) ]
             ~resolve:(fun _info _intarg ->
               let user_stream, push_to_user_stream = Lwt_stream.create () in
               let destroy_stream () = push_to_user_stream None in

--- a/graphql/src/graphql_intf.ml
+++ b/graphql/src/graphql_intf.ml
@@ -97,7 +97,11 @@ module type Schema = sig
     val arg : ?doc:string -> string -> typ:'a arg_typ -> 'a arg
 
     val arg' :
-      ?doc:string -> string -> typ:'a option arg_typ -> default:'a -> 'a arg
+      ?doc:string ->
+      string ->
+      typ:'a option arg_typ ->
+      default:Graphql_parser.const_value ->
+      'a arg
 
     val scalar :
       ?doc:string ->

--- a/graphql/src/graphql_schema.ml
+++ b/graphql/src/graphql_schema.ml
@@ -167,6 +167,7 @@ module Make (Io : IO) (Field_error : Field_error) = struct
           doc : string option;
           typ : 'a option arg_typ;
           default : 'a;
+          default_value : Graphql_parser.const_value;
         }
           -> 'a arg
 
@@ -174,23 +175,13 @@ module Make (Io : IO) (Field_error : Field_error) = struct
       | [] : ('a, 'a) arg_list
       | ( :: ) : 'a arg * ('b, 'c) arg_list -> ('b, 'a -> 'c) arg_list
 
-    let arg ?doc name ~typ = Arg { name; doc; typ }
-
-    let arg' ?doc name ~typ ~default = DefaultArg { name; doc; typ; default }
-
-    let scalar ?doc name ~coerce = Scalar { name; doc; coerce }
-
-    let enum ?doc name ~values = Enum { name; doc; values }
-
-    let obj ?doc name ~fields ~coerce = Object { name; doc; fields; coerce }
-
     let rec string_of_const_value : Graphql_parser.const_value -> string =
       function
-      | `Null -> "null"
-      | `Int i -> string_of_int i
-      | `Float f -> string_of_float f
-      | `String s -> Printf.sprintf "\"%s\"" s
-      | `Bool b -> string_of_bool b
+      | `Null -> Yojson.Basic.to_string `Null
+      | `Int i -> Yojson.Basic.to_string (`Int i)
+      | `Float f -> Yojson.Basic.to_string (`Float f)
+      | `String s -> Yojson.Basic.to_string (`String s)
+      | `Bool b -> Yojson.Basic.to_string (`Bool b)
       | `Enum e -> e
       | `List l ->
           let values = List.map (fun i -> string_of_const_value i) l in
@@ -401,6 +392,37 @@ module Make (Io : IO) (Field_error : Field_error) = struct
               Error
                 (Printf.sprintf "Expected enum for argument `%s` on field `%s`"
                    arg_name field_name) )
+
+    let arg ?doc name ~typ = Arg { name; doc; typ }
+
+    let arg' ?doc name ~typ ~default =
+      DefaultArg
+        {
+          name;
+          doc;
+          typ;
+          default_value = default;
+          default =
+            ( match
+                eval_arg StringMap.empty ~field_name:"" ~arg_name:name typ
+                  (Some default)
+              with
+            | Ok (Some v) -> v
+            | Ok None | Error _ ->
+                raise
+                  (Failure
+                     (Printf.sprintf
+                        "Invalid default provided for arg name=%s, default=%s"
+                        name
+                        (string_of_const_value default))) );
+        }
+
+    let scalar ?doc name ~coerce = Scalar { name; doc; coerce }
+
+    let enum ?doc name ~values = Enum { name; doc; values }
+
+    let obj ?doc name ~fields ~coerce = Object { name; doc; fields; coerce }
+
   end
 
   (* Schema data types *)
@@ -945,7 +967,10 @@ module Make (Io : IO) (Field_error : Field_error) = struct
                     typ = string;
                     args = Arg.[];
                     lift = Io.ok;
-                    resolve = (fun _ (AnyArg _) -> None);
+                    resolve = (fun _ (AnyArg arg) ->
+                        match arg with
+                        | Arg.DefaultArg a -> Some (Arg.string_of_const_value a.default_value)
+                        | Arg.Arg _ -> None);
                   };
               ];
         }

--- a/graphql/test/argument_test.ml
+++ b/graphql/test/argument_test.ml
@@ -133,4 +133,25 @@ let suite : (string * [> `Quick ] * (unit -> unit)) list =
         let query = "{ sum_defaults }" in
         test_query query
           (`Assoc [ ("data", `Assoc [ ("sum_defaults", `Int 45) ]) ]) );
+    ( "run-time error for invalid default arguments",
+      `Quick,
+      fun () ->
+        let res =
+          try
+            let _schema =
+              Graphql.Schema.(
+                schema [
+                  field
+                    "field"
+                    ~typ:(non_null int)
+                    ~args:Arg.[arg' "arg" ~typ:int ~default:(`String "1")]
+                    ~resolve:(fun _ () i -> i);
+                  ]
+              ) in
+            Error ()
+          with
+            Failure _ ->
+            Ok () in
+          Alcotest.(check (result unit unit)) "did not catch invalid default arg" (Ok ()) res;
+    )
   ]

--- a/graphql/test/echo_schema.ml
+++ b/graphql/test/echo_schema.ml
@@ -49,8 +49,8 @@ let schema =
           ~args:
             Arg.
               [
-                arg' "x" ~typ:string ~default:"42";
-                arg' "y" ~typ:int ~default:3;
+                arg' "x" ~typ:string ~default:(`String "42");
+                arg' "y" ~typ:int ~default:(`Int 3);
               ]
           ~resolve:(fun _ () x y ->
             try Some (int_of_string x + y) with _ -> None);

--- a/graphql/test/introspection_test.ml
+++ b/graphql/test/introspection_test.ml
@@ -208,6 +208,59 @@ let suite =
                         ] );
                   ] );
             ]) );
+    ( "__schema: defaultValue for args",
+      `Quick,
+      fun () ->
+        let schema =
+          Schema.(
+            schema
+              [
+                field "field" ~typ:(non_null string)
+                  ~args:
+                    Arg.
+                      [
+                        arg' "x" ~typ:string ~default:(`String "s");
+                        arg "y" ~typ:(non_null string);
+                      ]
+                  ~resolve:(fun _ _ x y -> x ^ y);
+              ])
+        in
+        let query =
+          {|{ __type(name: "query") { fields { args { name defaultValue } } } }|}
+        in
+        test_query schema query
+          (`Assoc
+            [
+              ( "data",
+                `Assoc
+                  [
+                    ( "__type",
+                      `Assoc
+                        [
+                          ( "fields",
+                            `List
+                              [
+                                `Assoc
+                                  [
+                                    ( "args",
+                                      `List
+                                        [
+                                          `Assoc
+                                            [
+                                              ("name", `String "y");
+                                              ("defaultValue", `Null);
+                                            ];
+                                          `Assoc
+                                            [
+                                              ("name", `String "x");
+                                              ("defaultValue", `String "\"s\"");
+                                            ];
+                                        ] );
+                                  ];
+                              ] );
+                        ] );
+                  ] );
+            ]) );
     ( "__type",
       `Quick,
       fun () ->

--- a/graphql/test/test_schema.ml
+++ b/graphql/test/test_schema.ml
@@ -72,9 +72,9 @@ let schema =
             ~args:
               Arg.
                 [
-                  arg' "error" ~typ:bool ~default:false;
-                  arg' "raise" ~typ:bool ~default:false;
-                  arg' "first" ~typ:int ~default:1;
+                  arg' "error" ~typ:bool ~default:(`Bool false);
+                  arg' "raise" ~typ:bool ~default:(`Bool false);
+                  arg' "first" ~typ:int ~default:(`Int 1);
                 ]
             ~resolve:(fun _ return_error raise_in_stream first ->
               if return_error then Error "stream error"


### PR DESCRIPTION
Per https://github.com/andreas/ocaml-graphql-server/issues/31#issuecomment-674311844, changes the type of the `~default` argument in `arg'` to `Graphql_parser.const_value` to make it possible to populate the `defaultValue` field in the introspection query.