### PR TITLE
Fix skip/include directives on fragment spreads

### DIFF
--- a/graphql/src/graphql_schema.ml
+++ b/graphql/src/graphql_schema.ml
@@ -1589,9 +1589,9 @@ module Make (Io : IO) (Field_error : Field_error) = struct
             if include_field then [ field ] else []
         | Graphql_parser.FragmentSpread spread -> (
             match StringMap.find spread.name ctx.fragments with
-            | Some { directives; type_condition; selection_set; _ }
+            | Some { type_condition; selection_set; _ }
               when matches_type_condition type_condition obj ->
-                should_include_field ctx directives >>= fun include_field ->
+                should_include_field ctx spread.directives >>= fun include_field ->
                 if include_field then collect_fields ctx obj selection_set
                 else Ok []
             | _ -> Ok [] )

--- a/graphql/test/directives_test.ml
+++ b/graphql/test/directives_test.ml
@@ -139,4 +139,24 @@ let suite =
                           ] );
                     ] );
               ]) );
+
+      ( "directives + fragment spread",
+        `Quick,
+        fun () ->
+          let query = "query Q { users { name ...F @include(if: false) } } fragment F on user { id } " in
+          test_query query
+            (`Assoc
+              [
+                ( "data",
+                  `Assoc
+                    [
+                      ( "users",
+                        `List
+                          [
+                            `Assoc [ ("name", `String "Alice") ];
+                            `Assoc [ ("name", `String "Bob") ];
+                            `Assoc [ ("name", `String "Charlie") ];
+                          ] );
+                    ] );
+              ]) );
   ]


### PR DESCRIPTION
Quick patch for skip/include directives on fragment spreads. 

The directives weren't being applied to the fragment spread because it was looking at the directives that were defined on the fragment definition (where skip and include aren't allowed).

In the example below, it was looking at (the made-up) `fragmentDefDirective` instead of the `skip` directive.

```
query TestQuery {
  test {
    ...TestFragment @skip(if: true)    
  }
}

fragment TestFragment on Test @fragmentDefDirective {
  id
}
```

Includes a test.