### PR TITLE
Fixes content-type + encoding issue

### DIFF
--- a/graphql-cohttp/src/graphql_cohttp.ml
+++ b/graphql-cohttp/src/graphql_cohttp.ml
@@ -84,7 +84,7 @@ module Params = struct
 
   let post_params_exn req body =
     let headers = Cohttp.Request.headers req in
-    match Cohttp.Header.get headers "Content-Type" with
+    match Cohttp.Header.get_media_type headers with
     | Some "application/graphql" -> of_graphql_body body
     | Some "application/json" -> of_json_body_exn body
     | _ -> empty

--- a/graphql-cohttp/test/request_test.ml
+++ b/graphql-cohttp/test/request_test.ml
@@ -33,6 +33,9 @@ let json_content_type =
 let graphql_content_type =
   Cohttp.Header.init_with "Content-Type" "application/graphql"
 
+let json_with_charset_content_type =
+  Cohttp.Header.init_with "Content-Type" "application/json ; charset=utf-8"
+
 let default_response_body =
   Yojson.Basic.to_string
     (`Assoc [ ("data", `Assoc [ ("hello", `String "world") ]) ])
@@ -183,6 +186,20 @@ let suite =
         let uri = Uri.with_uri ~query default_uri in
         test_case
           ~req:(Cohttp.Request.make ~meth:`POST ~headers:json_content_type uri)
+          ~req_body
+          ~rsp:(Cohttp.Response.make ~status:`OK ())
+          ~rsp_body:default_response_body );
+    ( "POST with json body including charset in content-type header",
+      `Quick,
+      fun () ->
+        let req_body =
+          Cohttp_lwt.Body.of_string
+            (Yojson.Basic.to_string (`Assoc [ ("query", `String "{ hello }") ]))
+        in
+        test_case
+          ~req:
+            (Cohttp.Request.make ~meth:`POST ~headers:json_with_charset_content_type
+               default_uri)
           ~req_body
           ~rsp:(Cohttp.Response.make ~status:`OK ())
           ~rsp_body:default_response_body );

--- a/graphql_parser/src/ast.ml
+++ b/graphql_parser/src/ast.ml
@@ -138,7 +138,7 @@ module Pp = struct
 
   and selection_set fmt =
     omit_empty_list
-      Fmt.(braces (hvbox ~indent:2 (prefix cut (list pp_selection))))
+      Fmt.(braces (hvbox ~indent:2 (cut ++ (list pp_selection))))
       fmt
 
   let rec pp_typ fmt = function


### PR DESCRIPTION
fix: issue where Fmt.prefix is deprecated, replaced with ( ++ ); 

fix: issue andreas/ocaml-graphql-server#196 where content-type containing an encoding would fail to process