### PR TITLE
Use Yojson `t` types instead of deprecated `json`

### DIFF
--- a/graphql-async.opam
+++ b/graphql-async.opam
@@ -18,6 +18,7 @@ depends: [
   "async_kernel" {>= "v0.9.0"}
   "alcotest" {with-test}
   "async_unix" {with-test & >= "v0.9.0"}
+  "yojson" {with-test & >= "1.6.0"}
 ]
 
 synopsis: "Build GraphQL schemas with Async support"

--- a/graphql-async/test/async_test.ml
+++ b/graphql-async/test/async_test.ml
@@ -2,16 +2,8 @@ open Async_kernel
 open Async_unix
 
 let yojson =
-  ( module struct
-    type t = Yojson.Basic.json [@@warning "-3"]
-
-    let pp formatter t =
-      Format.pp_print_text formatter (Yojson.Basic.pretty_to_string t)
-
-    let equal = ( = )
-  end : Alcotest.TESTABLE
-    with type t = Yojson.Basic.json )
-  [@@warning "-3"]
+  ( module Yojson.Basic : Alcotest.TESTABLE
+    with type t = Yojson.Basic.t )
 
 let test_query schema ctx query expected =
   Thread_safe.block_on_async_exn (fun () ->

--- a/graphql-async/test/dune
+++ b/graphql-async/test/dune
@@ -1,5 +1,5 @@
 (executable
- (libraries graphql-async alcotest async_kernel async_unix)
+ (libraries graphql-async alcotest async_kernel async_unix yojson)
  (name async_test))
 
 (alias

--- a/graphql-lwt.opam
+++ b/graphql-lwt.opam
@@ -16,6 +16,7 @@ depends: [
   "dune" {>= "1.1"}
   "graphql" {>= "0.13.0"}
   "alcotest" {with-test}
+  "yojson" {with-test & >= "1.6.0"}
   "lwt"
 ]
 

--- a/graphql-lwt/test/dune
+++ b/graphql-lwt/test/dune
@@ -1,5 +1,5 @@
 (executable
- (libraries graphql-lwt alcotest lwt.unix)
+ (libraries graphql-lwt alcotest lwt.unix yojson)
  (name lwt_test))
 
 (alias

--- a/graphql-lwt/test/lwt_test.ml
+++ b/graphql-lwt/test/lwt_test.ml
@@ -1,16 +1,8 @@
 open Lwt
 
 let yojson =
-  ( module struct
-    type t = Yojson.Basic.json [@@warning "-3"]
-
-    let pp formatter t =
-      Format.pp_print_text formatter (Yojson.Basic.pretty_to_string t)
-
-    let equal = ( = )
-  end : Alcotest.TESTABLE
-    with type t = Yojson.Basic.json )
-  [@@warning "-3"]
+  ( module Yojson.Basic : Alcotest.TESTABLE
+    with type t = Yojson.Basic.t )
 
 let test_query schema ctx query expected =
   Lwt_main.run

--- a/graphql.opam
+++ b/graphql.opam
@@ -15,7 +15,7 @@ depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "1.1"}
   "graphql_parser" {>= "0.9.0"}
-  "yojson"
+  "yojson" {>= "1.6.0"}
   "rresult"
   "seq"
   "alcotest" {with-test}

--- a/graphql/src/graphql_intf.ml
+++ b/graphql/src/graphql_intf.ml
@@ -27,7 +27,7 @@ module type Field_error = sig
   val message_of_field_error : t -> string
 
   val extensions_of_field_error :
-    t -> ((string * Yojson.Basic.json)[@warning "-3"]) list option
+    t -> (string * Yojson.Basic.t) list option
 end
 
 (** GraphQL schema signature *)
@@ -188,10 +188,10 @@ module type Schema = sig
     ?doc:string -> string -> values:'a enum_value list -> ('ctx, 'a option) typ
 
   val scalar :
-    (?doc:string ->
-     string ->
-     coerce:('a -> Yojson.Basic.json) ->
-     ('ctx, 'a option) typ[@warning "-3"])
+    ?doc:string ->
+    string ->
+    coerce:('a -> Yojson.Basic.t) ->
+    ('ctx, 'a option) typ
 
   val list : ('ctx, 'src) typ -> ('ctx, 'src list option) typ
 
@@ -251,18 +251,18 @@ module type Schema = sig
 
   type variables = (string * Graphql_parser.const_value) list
 
-  type 'a response = (('a, Yojson.Basic.json) result[@warning "-3"])
+  type 'a response = ('a, Yojson.Basic.t) result
 
   val execute :
-    ('ctx schema ->
-     'ctx ->
-     ?variables:variables ->
-     ?operation_name:string ->
-     Graphql_parser.document ->
-     [ `Response of Yojson.Basic.json
-     | `Stream of Yojson.Basic.json response Io.Stream.t ]
-     response
-     Io.t[@warning "-3"])
+    'ctx schema ->
+    'ctx ->
+    ?variables:variables ->
+    ?operation_name:string ->
+    Graphql_parser.document ->
+    [ `Response of Yojson.Basic.t
+    | `Stream of Yojson.Basic.t response Io.Stream.t ]
+    response
+    Io.t
   (** [execute schema ctx variables doc] evaluates the [doc] against [schema]
       with the given context [ctx] and [variables]. *)
 end

--- a/graphql/src/graphql_schema.ml
+++ b/graphql/src/graphql_schema.ml
@@ -54,7 +54,7 @@ module type Field_error = sig
   val message_of_field_error : t -> string
 
   val extensions_of_field_error :
-    t -> ((string * Yojson.Basic.json)[@warning "-3"]) list option
+    t -> (string * Yojson.Basic.t) list option
 end
 
 (* Schema *)
@@ -122,7 +122,7 @@ module Make (Io : IO) (Field_error : Field_error) = struct
     value : 'a;
   }
 
-  type json = (Yojson.Basic.json[@warning "-3"])
+  type json = Yojson.Basic.t
 
   let enum_value ?doc ?(deprecated = NotDeprecated) name ~value =
     { name; doc; deprecated; value }

--- a/graphql/test/test_common.ml
+++ b/graphql/test/test_common.ml
@@ -1,13 +1,6 @@
 let yojson =
-  ( module struct
-    type t = Yojson.Basic.json
-
-    let pp = Yojson.Basic.pretty_print ?std:None
-
-    let equal = ( = )
-  end : Alcotest.TESTABLE
-    with type t = Yojson.Basic.json )
-  [@@warning "-3"]
+  ( module Yojson.Basic : Alcotest.TESTABLE
+    with type t = Yojson.Basic.t )
 
 let list_of_seq seq =
   let rec loop seq =


### PR DESCRIPTION
This fixes compatibility for the upcoming Yojson 2 while still working with Yojson >= 1.6.