### PR TITLE
Raise minimum `rresult` version

### DIFF
--- a/graphql.opam
+++ b/graphql.opam
@@ -16,7 +16,7 @@ depends: [
   "dune" {>= "1.1"}
   "graphql_parser" {>= "0.9.0"}
   "yojson"
-  "rresult"
+  "rresult" {>= "0.3.0"}
   "seq"
   "alcotest" {with-test}
 ]


### PR DESCRIPTION
The code needs at least version 0.2.0 of `rresult` for `>>=` and it needs at least 0.3.0 for `rresult` to use the `result` compatibility package to define a `result` type that is compatible with the stdlib `result` type.

Discovered via the minimum-version checks of https://github.com/ocaml/opam-repository/pull/21475