### PR TITLE
Update Graphiql version

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,1 +1,2 @@
+version = 0.26.2
 profile = conventional

--- a/dune-project
+++ b/dune-project
@@ -3,5 +3,3 @@
 (name ocaml-graphql-server)
 
 (using menhir 2.0)
-
-(using fmt 1.2)

--- a/graphql-async.opam
+++ b/graphql-async.opam
@@ -5,6 +5,7 @@ homepage: "https://github.com/andreas/ocaml-graphql-server"
 doc: "https://andreas.github.io/ocaml-graphql-server/"
 bug-reports: "https://github.com/andreas/ocaml-graphql-server/issues"
 dev-repo: "git+https://github.com/andreas/ocaml-graphql-server.git"
+license: "MIT"
 
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/graphql-async.opam
+++ b/graphql-async.opam
@@ -19,6 +19,7 @@ depends: [
   "alcotest" {with-test}
   "async_unix" {with-test & >= "v0.9.0"}
   "yojson" {with-test & >= "1.6.0"}
+  "ppx_sexp_conv" {>= "v0.16.0"}
 ]
 
 synopsis: "Build GraphQL schemas with Async support"

--- a/graphql-async/src/graphql_async.ml
+++ b/graphql-async/src/graphql_async.ml
@@ -10,10 +10,9 @@ module Schema =
 
         let map t f =
           Async_kernel.Pipe.map' t ~f:(fun q ->
-              Async_kernel.Deferred.Queue.map q ~f)
+              Async_kernel.Deferred.Queue.map q ~f ~how:`Sequential)
 
         let iter t f = Async_kernel.Pipe.iter t ~f
-
         let close = Async_kernel.Pipe.close_read
       end
     end)
@@ -21,6 +20,5 @@ module Schema =
       type t = string
 
       let message_of_field_error t = t
-
       let extensions_of_field_error _t = None
     end)

--- a/graphql-cohttp.opam
+++ b/graphql-cohttp.opam
@@ -5,6 +5,7 @@ homepage: "https://github.com/andreas/ocaml-graphql-server"
 doc: "https://andreas.github.io/ocaml-graphql-server/"
 bug-reports: "https://github.com/andreas/ocaml-graphql-server/issues"
 dev-repo: "git+https://github.com/andreas/ocaml-graphql-server.git"
+license: "MIT"
 
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/graphql-cohttp/src/assets/index.html
+++ b/graphql-cohttp/src/assets/index.html
@@ -1,122 +1,117 @@
-
-<!--
-The request to this GraphQL server provided the header "Accept: text/html"
-and as a result has been presented GraphiQL - an in-browser IDE for
-exploring GraphQL.
-
-If you wish to receive JSON, provide the header "Accept: application/json" or
-add "&raw" to the end of the URL within a browser.
--->
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
+  <meta charset="utf-8" />
+  <meta name="robots" content="noindex" />
+  <meta name="referrer" content="origin" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>GraphQL API</title>
   <style>
-    html, body {
-      height: 100%;
+    body {
+      height: 100vh;
       margin: 0;
       overflow: hidden;
-      width: 100%;
+    }
+    #splash {
+      color: #333;
+      display: flex;
+      flex-direction: column;
+      font-family: system, -apple-system, "San Francisco", ".SFNSDisplay-Regular", "Segoe UI", Segoe, "Segoe WP", "Helvetica Neue", helvetica, "Lucida Grande", arial, sans-serif;
+      height: 100vh;
+      justify-content: center;
+      text-align: center;
     }
   </style>
-  <link href="//cdn.jsdelivr.net/npm/graphiql@0.12.0/graphiql.css" rel="stylesheet" />
-  <script src="//cdn.jsdelivr.net/react/15.4.2/react.min.js"></script>
-  <script src="//cdn.jsdelivr.net/react/15.4.2/react-dom.min.js"></script>
-  <script src="//cdn.jsdelivr.net/npm/graphiql@0.12.0/graphiql.js"></script>
-  <script src="//unpkg.com/subscriptions-transport-ws@0.8.1/browser/client.js"></script>
-  <script src="//unpkg.com/graphiql-subscriptions-fetcher@0.0.2/browser/client.js"></script>
+  <link rel="icon" href="favicon.ico">
+  <link type="text/css" href="//unpkg.com/graphiql/graphiql.min.css" rel="stylesheet" />
 </head>
 <body>
+  <div id="splash">
+    Loading&hellip;
+  </div>
+  <script src="//cdn.jsdelivr.net/es6-promise/4.0.5/es6-promise.auto.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/react/umd/react.production.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/react-dom/umd/react-dom.production.min.js"></script>
+  <script src="//unpkg.com/graphiql/graphiql.min.js"></script>
   <script>
-    // Collect the URL parameters
-    var parameters = {};
-    window.location.search.substr(1).split('&').forEach(function (entry) {
-      var eq = entry.indexOf('=');
-      if (eq >= 0) {
-        parameters[decodeURIComponent(entry.slice(0, eq))] =
-          decodeURIComponent(entry.slice(eq + 1));
-      }
-    });
-
-    // Produce a Location query string from a parameter object.
-    function locationQuery(params) {
-      return '?' + Object.keys(params).map(function (key) {
-        return encodeURIComponent(key) + '=' +
-          encodeURIComponent(params[key]);
-      }).join('&');
-    }
-
-    // Derive a fetch URL from the current URL, sans the GraphQL parameters.
-    var graphqlParamNames = {
-      query: true,
-      variables: true,
-      operationName: true
-    };
-
-    var otherParams = {};
-    for (var k in parameters) {
-      if (parameters.hasOwnProperty(k) && graphqlParamNames[k] !== true) {
-        otherParams[k] = parameters[k];
-      }
-    }
-    // Defines a GraphQL fetcher using the fetch API.
-    function graphQLFetcher(graphQLParams) {
-      return fetch(window.location, {
-        method: 'post',
-        headers: {
-          'Accept': 'application/json',
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify(graphQLParams),
-      }).then(function (response) {
-        return response.text();
-      }).then(function (responseBody) {
-        try {
-          return JSON.parse(responseBody);
-        } catch (error) {
-          return responseBody;
+      // Parse the search string to get url parameters.
+      var search = window.location.search;
+      var parameters = {};
+      search.substr(1).split('&').forEach(function (entry) {
+        var eq = entry.indexOf('=');
+        if (eq >= 0) {
+          parameters[decodeURIComponent(entry.slice(0, eq))] =
+            decodeURIComponent(entry.slice(eq + 1));
         }
       });
-    }
 
-    // When the query and variables string is edited, update the URL bar so
-    // that it can be easily shared.
-    function onEditQuery(newQuery) {
-      parameters.query = newQuery;
-      updateURL();
-    }
+      // if variables was provided, try to format it.
+      if (parameters.variables) {
+        try {
+          parameters.variables =
+            JSON.stringify(JSON.parse(parameters.variables), null, 2);
+        } catch (e) {
+          // Do nothing, we want to display the invalid JSON as a string, rather
+          // than present an error.
+        }
+      }
 
-    function onEditVariables(newVariables) {
-      parameters.variables = newVariables;
-      updateURL();
-    }
+      // When the query and variables string is edited, update the URL bar so
+      // that it can be easily shared
+      function onEditQuery(newQuery) {
+        parameters.query = newQuery;
+        updateURL();
+      }
+      function onEditVariables(newVariables) {
+        parameters.variables = newVariables;
+        updateURL();
+      }
+      function onEditOperationName(newOperationName) {
+        parameters.operationName = newOperationName;
+        updateURL();
+      }
+      function updateURL() {
+        var newSearch = '?' + Object.keys(parameters).filter(function (key) {
+          return Boolean(parameters[key]);
+        }).map(function (key) {
+          return encodeURIComponent(key) + '=' +
+            encodeURIComponent(parameters[key]);
+        }).join('&');
+        history.replaceState(null, null, newSearch);
+      }
 
-    function onEditOperationName(newOperationName) {
-      parameters.operationName = newOperationName;
-      updateURL();
-    }
+       function graphQLFetcher(graphQLParams) {
+          return fetch(window.location, {
+            method: 'post',
+            headers: {
+              'Accept': 'application/json',
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(graphQLParams),
+          }).then(function (response) {
+            return response.text();
+          }).then(function (responseBody) {
+            try {
+              return JSON.parse(responseBody);
+            } catch (error) {
+              return responseBody;
+            }
+          });
+        }
 
-    function updateURL() {
-      history.replaceState(null, null, locationQuery(parameters));
-    }
-
-    var subscriptionsClient = new SubscriptionsTransportWs.SubscriptionClient('ws://' + window.location.host + window.location.pathname, { reconnect: true });
-
-    var subscriptionsFetcher = GraphiQLSubscriptionsFetcher.graphQLFetcher(subscriptionsClient, graphQLFetcher);
-
-    // Render <GraphiQL /> into the body.
-    ReactDOM.render(
-      React.createElement(GraphiQL, {
-        fetcher: subscriptionsFetcher,
-        onEditQuery: onEditQuery,
-        onEditVariables: onEditVariables,
-        onEditOperationName: onEditOperationName,
-        query: parameters.query,
-        response: parameters.response,
-        variables: parameters.variables,
-        operationName: parameters.operationName,
-      }),
-      document.body
-    );
+      // Render <GraphiQL /> into the body.
+      ReactDOM.render(
+        React.createElement(GraphiQL, {
+          fetcher: graphQLFetcher,
+          query: parameters.query,
+          variables: parameters.variables,
+          operationName: parameters.operationName,
+          onEditQuery: onEditQuery,
+          onEditVariables: onEditVariables,
+          onEditOperationName: onEditOperationName
+        }),
+        document.body,
+      );
   </script>
 </body>
 </html>

--- a/graphql-lwt.opam
+++ b/graphql-lwt.opam
@@ -5,6 +5,7 @@ homepage: "https://github.com/andreas/ocaml-graphql-server"
 doc: "https://andreas.github.io/ocaml-graphql-server/"
 bug-reports: "https://github.com/andreas/ocaml-graphql-server/issues"
 dev-repo: "git+https://github.com/andreas/ocaml-graphql-server.git"
+license: "MIT"
 
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/graphql.opam
+++ b/graphql.opam
@@ -5,6 +5,7 @@ homepage: "https://github.com/andreas/ocaml-graphql-server"
 doc: "https://andreas.github.io/ocaml-graphql-server/"
 bug-reports: "https://github.com/andreas/ocaml-graphql-server/issues"
 dev-repo: "git+https://github.com/andreas/ocaml-graphql-server.git"
+license: "MIT"
 
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/graphql_parser.opam
+++ b/graphql_parser.opam
@@ -5,6 +5,7 @@ homepage: "https://github.com/andreas/ocaml-graphql-server"
 doc: "https://andreas.github.io/ocaml-graphql-server/"
 bug-reports: "https://github.com/andreas/ocaml-graphql-server/issues"
 dev-repo: "git+https://github.com/andreas/ocaml-graphql-server.git"
+license: "MIT"
 
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/graphql_parser.opam
+++ b/graphql_parser.opam
@@ -16,7 +16,7 @@ depends: [
   "dune" {>= "1.1"}
   "menhir" {build}
   "alcotest" {with-test & >= "0.8.1"}
-  "fmt"
+  "fmt" {>= "0.8.7"}
   "re" {>= "1.5.0"}
 ]
 

--- a/graphql_parser.opam
+++ b/graphql_parser.opam
@@ -15,7 +15,7 @@ build: [
 depends: [
   "ocaml" {>= "4.03.0"}
   "dune" {>= "1.1"}
-  "menhir" {build}
+  "menhir" {build & >= "20220210"}
   "alcotest" {with-test & >= "0.8.1"}
   "fmt" {>= "0.8.7"}
   "re" {>= "1.5.0"}


### PR DESCRIPTION
The previous version (0.12.0) of Graphiql lead to some issues ( https://github.com/mirage/irmin/issues/2320 ) when using its history tab, as it would populate the extra-parameters `variables=null` and `operationName=undefined` which are invalid values. Updating the UI seems to do the trick! (I grabbed the html/js source from graphiql live demo at https://graphql.github.io/swapi-graphql/ and only replaced the `fetch` url to `window.location` like was present before)